### PR TITLE
Merging edmitriev/biginfra-532

### DIFF
--- a/src/main/java/com/booking/replication/Replicator.java
+++ b/src/main/java/com/booking/replication/Replicator.java
@@ -48,6 +48,7 @@ public class Replicator {
     public Replicator(Configuration configuration, ReplicatorHealthTrackerProxy healthTracker, Counter interestingEventsObservedCounter) throws Exception {
 
         this.healthTracker = healthTracker;
+        long fakeMicrosecondCounter = 0;
 
         boolean mysqlFailoverActive = false;
         if (configuration.getMySQLFailover() != null) {
@@ -94,6 +95,7 @@ public class Replicator {
                 if ( safeCheckPoint != null ) {
 
                     String pseudoGTID = safeCheckPoint.getPseudoGTID();
+                    fakeMicrosecondCounter = safeCheckPoint.getFakeMicrosecondCounter();
 
                     if (pseudoGTID != null) {
 
@@ -277,7 +279,8 @@ public class Replicator {
             pipelinePosition,
             configuration,
             applier,
-            replicantPool
+            replicantPool,
+            fakeMicrosecondCounter
     );
 
         // Overseer

--- a/src/main/java/com/booking/replication/checkpoints/LastCommittedPositionCheckpoint.java
+++ b/src/main/java/com/booking/replication/checkpoints/LastCommittedPositionCheckpoint.java
@@ -22,9 +22,10 @@ public class LastCommittedPositionCheckpoint implements SafeCheckPoint {
 
     private String pseudoGTID;
     private String pseudoGTIDFullQuery;
+    private long fakeMicrosecondCounter = 0L;
 
-    public LastCommittedPositionCheckpoint(int slaveId, String binlogFileName) {
-        this(slaveId, binlogFileName, 4L);
+    public LastCommittedPositionCheckpoint(int slaveId, String binlogFileName, long fakeMicrosecondCounter) {
+        this(slaveId, binlogFileName, 4L, fakeMicrosecondCounter);
     }
 
     public LastCommittedPositionCheckpoint() {
@@ -41,12 +42,14 @@ public class LastCommittedPositionCheckpoint implements SafeCheckPoint {
     public LastCommittedPositionCheckpoint(
         int slaveId,
         String binlogFileName,
-        long binlogPosition
+        long binlogPosition,
+        long fakeMicrosecondCounter
     ) {
         this.slaveId = slaveId;
         lastVerifiedBinlogFileName = binlogFileName;
         lastVerifiedBinlogPosition = binlogPosition;
         checkpointType = SafeCheckpointType.BINLOG_POSITION;
+        this.fakeMicrosecondCounter = fakeMicrosecondCounter;
     }
 
     /**
@@ -65,7 +68,8 @@ public class LastCommittedPositionCheckpoint implements SafeCheckPoint {
         String binlogFileName,
         long binlogPosition,
         String pseudoGTID,
-        String pseudoGTIDFullQuery
+        String pseudoGTIDFullQuery,
+        long fakeMicrosecondCounter
     ) {
         this.hostName                   = hostName;
         this.slaveId                    = slaveId;
@@ -74,6 +78,7 @@ public class LastCommittedPositionCheckpoint implements SafeCheckPoint {
         this.pseudoGTID                 = pseudoGTID;
         this.pseudoGTIDFullQuery        = pseudoGTIDFullQuery;
         this.checkpointType             = SafeCheckpointType.GLOBAL_PSEUDO_GTID;
+        this.fakeMicrosecondCounter     = fakeMicrosecondCounter;
     }
 
     @Override
@@ -95,6 +100,10 @@ public class LastCommittedPositionCheckpoint implements SafeCheckPoint {
 
     public String getPseudoGTID() {
         return pseudoGTID;
+    }
+
+    public long getFakeMicrosecondCounter() {
+        return fakeMicrosecondCounter;
     }
 
     public String getHostName() {

--- a/src/main/java/com/booking/replication/util/BinlogCoordinatesFinder.java
+++ b/src/main/java/com/booking/replication/util/BinlogCoordinatesFinder.java
@@ -209,7 +209,7 @@ public class BinlogCoordinatesFinder {
         try ( PreparedStatement statement = connection.prepareStatement("SHOW BINLOG EVENTS IN ? LIMIT ?,?")){
 
             int start = 0;
-            int limit = 500;
+            int limit = 5000;
 
             for (;;){
 


### PR DESCRIPTION
Fixes wrong ordering of events which might occurred when the same cell was updated multiple times during one second and fakeMicrosecondCounter was resetted between the two updates. Stores fakeMicrosecondCounter in metadata because we can't reset it when gtid arrives (will break order).
Improves speed of searching GTID in binary log on startup by reducing amount of iterations with mysql server.