### PR TITLE
mabbady/partitioning methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,19 @@ kafka:
     broker: "kafka-broker-1:port,...,kafka-broken-N:port"
     topic:  topic_name
     # tables to replicate to kafka, can be either a list of tables,
-    # or an exlcussion filter
+    # or an exclusion filter
     tables: ["table_1", ..., "table_N"]
-    excludetables: ["exlude_pattern_1",..., "exclude_pattern_N"]
+    excludetables: ["exclude_pattern_1",..., "exclude_pattern_N"]
+    # events are distributed to paritions based on the hash of the table name by default. There are other settings:
+    # 0: using the row object hash.
+    # 1: using the table name hash (default).
+    # 2: using the values in the primary column.
+    # 3: using the specified column names (if none is specified, it will default to the table name).
+    partitioning_method: 3
+    partition_columns:
+        table_name: column_name
+        another_table: another_column
+
 hbase:
     namespace: 'schema_namespace'
     zookeeper_quorum:  ['hbase-zk1-host', 'hbase-zkN-host']

--- a/src/main/java/com/booking/replication/Configuration.java
+++ b/src/main/java/com/booking/replication/Configuration.java
@@ -145,7 +145,7 @@ public class Configuration {
     @JsonDeserialize
     private KafkaConfiguration kafka = new KafkaConfiguration();
 
-    private static class KafkaConfiguration {
+    public static class KafkaConfiguration {
         public String broker;
         public List<String> tables;
         public List<String> excludetables;
@@ -521,7 +521,7 @@ public class Configuration {
         }
     }
     /**
-     * Augmenter configuation getters.
+     * Augmenter configuration getters.
      */
     public boolean getAugmenterApplyUuid(){
         return augmenterConfiguration.apply_uuid;
@@ -531,7 +531,7 @@ public class Configuration {
     }
 
     /**
-     * Kafka configuation getters.
+     * Kafka configuration getters.
      */
     public String getKafkaBrokerAddress() {
         return kafka.broker;
@@ -561,5 +561,16 @@ public class Configuration {
         return dryRunMode;
     }
 
+    /**
+     * Kafka configuration setters
+     */
+
+    public void setKafka(KafkaConfiguration kafka) {
+        this.kafka = kafka;
+    }
+
+    public void setDryRunMode(boolean dryRunMode) {
+        this.dryRunMode = dryRunMode;
+    }
 
 }

--- a/src/main/java/com/booking/replication/Configuration.java
+++ b/src/main/java/com/booking/replication/Configuration.java
@@ -149,12 +149,19 @@ public class Configuration {
         public String broker;
         public List<String> tables;
         public List<String> excludetables;
+        public int partitioning_method = PARTITIONING_METHOD_HASH_TABLE_NAME;
+        public HashMap<String, String> partition_columns;
         public String topic;
         @JsonProperty("apply_begin_event")
         public Boolean applyBeginEvent = false;
         @JsonProperty("apply_commit_event")
         public Boolean applyCommitEvent = false;
     }
+
+    public static final int PARTITIONING_METHOD_HASH_ROW = 0;
+    public static final int PARTITIONING_METHOD_HASH_TABLE_NAME = 1;
+    public static final int PARTITIONING_METHOD_HASH_PRIMARY_COLUMN = 2;
+    public static final int PARTITIONING_METHOD_HASH_CUSTOM_COLUMN = 3;
 
     public static class ValidationConfiguration {
         private String broker;
@@ -541,6 +548,10 @@ public class Configuration {
     public String getKafkaTopicName() {
         return kafka.topic;
     }
+
+    public int getKafkaPartitioningMethod() { return kafka.partitioning_method; }
+
+    public HashMap<String, String> getKafkaPartitionColumns() { return kafka.partition_columns; }
 
     public boolean isKafkaApplyBeginEvent() { return kafka.applyBeginEvent; }
 

--- a/src/main/java/com/booking/replication/augmenter/AugmentedRow.java
+++ b/src/main/java/com/booking/replication/augmenter/AugmentedRow.java
@@ -243,8 +243,16 @@ public class AugmentedRow {
         return eventColumns;
     }
 
+    public void setEventColumns(Map<String, Map<String, String>> eventColumns) {
+        this.eventColumns = eventColumns;
+    }
+
     public TableSchemaVersion getTableSchemaVersion() {
         return tableSchemaVersion;
+    }
+
+    public void setPrimaryKeyColumns(List<String> primaryKeyColumns) {
+        this.primaryKeyColumns = primaryKeyColumns;
     }
 
     public List<String> getPrimaryKeyColumns() {

--- a/src/main/java/com/booking/replication/pipeline/event/handler/EventDispatcher.java
+++ b/src/main/java/com/booking/replication/pipeline/event/handler/EventDispatcher.java
@@ -42,7 +42,7 @@ public class EventDispatcher implements BinlogEventV4Handler {
             LOGGER.debug("Applying event: " + event + ", handler: " + eventHandler);
             eventHandler.apply(event, currentTransaction);
         } catch (Exception e) {
-            throw new EventHandlerApplyException("Failed to apply event: ", e);
+            throw new EventHandlerApplyException("Failed to apply event:", e);
         }
     }
 

--- a/src/main/java/com/booking/replication/replicant/MysqlReplicantPool.java
+++ b/src/main/java/com/booking/replication/replicant/MysqlReplicantPool.java
@@ -92,7 +92,7 @@ public class MysqlReplicantPool implements ReplicantPool {
         replicantDataSource.setDriverClassName("com.mysql.jdbc.Driver");
 
         String replicantDSN =
-            String.format("jdbc:mysql://%s/%s", host, configuration.getReplicantSchemaName());
+            String.format("jdbc:mysql://%s", host);
 
         replicantDataSource.setUrl(replicantDSN);
 


### PR DESCRIPTION
Partitioning data to kafka works currently by hashing the table name from the binlog event (if exists). This request is for supporting other sources for the hash:
- Primary key values.
- Value from a specific column for each table.