### PR TITLE
Fix for microsecond managing logic for a case when single cell is affected several times in a transaction

### DIFF
--- a/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
+++ b/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
@@ -345,7 +345,7 @@ public class HBaseApplierMutationGenerator {
         return String.format("mysql://%s/%s?%s", configuration.validationConfig.getSourceDomain(), table, keys  );
     }
 
-    private static String getHBaseRowKey(AugmentedRow row) {
+    public static String getHBaseRowKey(AugmentedRow row) {
         // RowID
         // This is sorted by column OP (from information schema)
         List<String> pkColumnNames  = row.getPrimaryKeyColumns();

--- a/src/main/java/com/booking/replication/applier/hbase/HBaseApplierWriter.java
+++ b/src/main/java/com/booking/replication/applier/hbase/HBaseApplierWriter.java
@@ -84,6 +84,7 @@ public class HBaseApplierWriter {
         ConcurrentHashMap<String, String> taskUUIDToPseudoGTID = new ConcurrentHashMap<>();
 
     private static LastCommittedPositionCheckpoint latestCommittedPseudoGTIDCheckPoint;
+    private final RowTimestampOrganizer timestampOrganizer;
     /**
      * Shared connection used by all tasks in applier.
      */
@@ -171,6 +172,7 @@ public class HBaseApplierWriter {
         taskPool          = Executors.newFixedThreadPool(this.poolSize);
 
         mutationGenerator = new HBaseApplierMutationGenerator(configuration);
+        timestampOrganizer = new RowTimestampOrganizer();
 
         hbaseConf.set("hbase.zookeeper.quorum", configuration.getHBaseQuorum());
         hbaseConf.set("hbase.client.keyvalue.maxsize", "0");
@@ -286,6 +288,7 @@ public class HBaseApplierWriter {
         }
 
         List<AugmentedRow> augmentedRows  = augmentedRowsEvent.getSingleRowEvents();
+        timestampOrganizer.organizeTimestamps(augmentedRows, mySQLTableName, currentTransactionUUID);
 
         // Add to buffer
         for (AugmentedRow augmentedRow : augmentedRows) {

--- a/src/main/java/com/booking/replication/applier/hbase/RowTimestampOrganizer.java
+++ b/src/main/java/com/booking/replication/applier/hbase/RowTimestampOrganizer.java
@@ -1,0 +1,79 @@
+package com.booking.replication.applier.hbase;
+
+import com.booking.replication.augmenter.AugmentedRow;
+import com.google.code.or.binlog.impl.event.BinlogEventV4HeaderImpl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.booking.replication.applier.hbase.HBaseApplierMutationGenerator.getHBaseRowKey;
+
+/**
+ * This class takes care that all HBase rows with same row_id in same table have different timestamp.
+ *
+ * Sometimes one may observe long-lasting transactions with query time few minutes before commit time
+ * So writing data with query time may lead to situation that
+ *   data would be seen existing some time before it really existed
+ * So we want to write replicated changes with time of transaction commit - not time of query
+ *
+ * Setting one single time to all events in transaction is dangerous for a case when there are several
+ *   modifications of one cell in a transaction
+ * When all of these changes have same timestamp only one (one that was written last) will be stored in HBase
+ * So we may loose fact of changes
+ * Or because of asynchronous processing event written last will be not really last so we will have differences
+ *   between source data and final version of HBase data
+ *
+ * We want to avoid this situation
+ * So we want to set different timestamps to different events in single transaction.
+ * If transaction is very big then setting different timestamp to every event is risky
+ *   because it may cause transactions overlapping
+ * So we would like to change timestamps to different for every row: primary-key and table combination
+ *
+ * To achieve this we put 1st row for every table/pk combination SPAN (50 in current implementation)
+ *   microseconds before finish timestamp.
+ * Every next event for this table/PK combination will be put 1 microsecond later
+ * With exception when reaching SPAN (50 in current implementation) events when all later ones
+ *   will have timestamp equal to finish event
+ *
+ * So here we assume all event timestamps in transaction were set to finish events.
+ * We support up to 50 changes for 1 table/PK combinations in 1 transaction
+ */
+public class RowTimestampOrganizer {
+
+    private class TimestampTuple {
+        public long timestamp;
+        public long maximumTimestamp;
+        public TimestampTuple(long timestamp, long maximumTimestamp) {
+            this.timestamp = timestamp;
+            this.maximumTimestamp = maximumTimestamp;
+        }
+    }
+    private static final long TIMESTAMP_SPAN_MISCROSECONDS = 50;
+
+    private String currentTransactionUUID = null;
+    private Map<String, TimestampTuple> timestampsCache;
+
+    public void organizeTimestamps(List<AugmentedRow> rows, String mysqlTableName, String transactionUUID) {
+        if (currentTransactionUUID != transactionUUID) {
+            currentTransactionUUID = transactionUUID;
+            timestampsCache = new HashMap<>();
+        }
+        for (AugmentedRow row : rows) {
+            String key = mysqlTableName + ":" + getHBaseRowKey(row);
+            TimestampTuple v;
+            if (timestampsCache.containsKey(key)) {
+                v = timestampsCache.get(key);
+                if (v.timestamp < v.maximumTimestamp) {
+                    v.timestamp++;
+                }
+            } else {
+                v = new TimestampTuple(
+                        row.getEventV4Header().getTimestamp() - TIMESTAMP_SPAN_MISCROSECONDS,
+                        row.getEventV4Header().getTimestamp());
+            }
+            ((BinlogEventV4HeaderImpl) row.getEventV4Header()).setTimestamp(v.timestamp);
+        }
+    }
+
+}


### PR DESCRIPTION
Follow up on #6. We don't want all events in one transaction to have same timestamp - sometimes there are several events changing one field in transaction and sometimes these events are interesting.

Setting one single time to all events in transaction is dangerous for a case when there are several
   modifications of one cell in a transaction
 When all of these changes have same timestamp only one (one that was written last) will be stored in HBase
 So we may loose fact of changes
 Or because of asynchronous processing event written last will be not really last so we will have differences
   between source data and final version of HBase data

 We want to avoid this situation
 So we want to set different timestamps to different events in single transaction.
 If transaction is very big then setting different timestamp to every event is risky
   because it may cause transactions overlapping
 So we would like to change timestamps to different for every row: primary-key and table combination

 To achieve this we put 1st row for every table/pk combination SPAN (50 in current implementation)
   microseconds before finish timestamp.
 Every next event for this table/PK combination will be put 1 microsecond later
 With exception when reaching SPAN (50 in current implementation) events when all later ones
   will have timestamp equal to finish event