### PR TITLE
Converter refactoring and test

### DIFF
--- a/src/main/java/com/booking/replication/binlog/common/cell/DateCell.java
+++ b/src/main/java/com/booking/replication/binlog/common/cell/DateCell.java
@@ -22,4 +22,7 @@ public class DateCell implements Cell {
     public Date getValue() {
         return value;
     }
+
+    @Override
+    public String toString() { return value.toString(); }
 }

--- a/src/main/java/com/booking/replication/binlog/common/cell/Datetime2Cell.java
+++ b/src/main/java/com/booking/replication/binlog/common/cell/Datetime2Cell.java
@@ -19,4 +19,7 @@ public class Datetime2Cell implements Cell {
     public Date getValue() {
         return value;
     }
+
+    @Override
+    public String toString() { return value.toString(); }
 }

--- a/src/main/java/com/booking/replication/binlog/common/cell/DatetimeCell.java
+++ b/src/main/java/com/booking/replication/binlog/common/cell/DatetimeCell.java
@@ -19,4 +19,7 @@ public class DatetimeCell implements Cell {
     public Date getValue() {
         return value;
     }
+
+    @Override
+    public String toString() { return value.toString(); }
 }

--- a/src/main/java/com/booking/replication/binlog/common/cell/DoubleCell.java
+++ b/src/main/java/com/booking/replication/binlog/common/cell/DoubleCell.java
@@ -17,4 +17,7 @@ public class DoubleCell implements Cell {
     public Double getValue() {
         return value;
     }
+
+    @Override
+    public String toString() { return Double.toString(value); }
 }

--- a/src/main/java/com/booking/replication/binlog/common/cell/Time2Cell.java
+++ b/src/main/java/com/booking/replication/binlog/common/cell/Time2Cell.java
@@ -17,4 +17,9 @@ public class Time2Cell implements Cell {
     public java.sql.Time getValue() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        return Long.toString(value.getTime());
+    }
 }

--- a/src/main/java/com/booking/replication/binlog/common/cell/TimeCell.java
+++ b/src/main/java/com/booking/replication/binlog/common/cell/TimeCell.java
@@ -17,4 +17,9 @@ public class TimeCell implements Cell {
     public java.sql.Time getValue() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        return Long.toString(value.getTime());
+    }
 }

--- a/src/main/java/com/booking/replication/schema/column/ColumnSchema.java
+++ b/src/main/java/com/booking/replication/schema/column/ColumnSchema.java
@@ -11,7 +11,7 @@ public class ColumnSchema {
     private String columnName;
     private String columnKey;
     private String characterSetName;
-    private String dataType;
+    private String dataType; // TODO: Duplicates columnType. Remove
     private String columnType;
     private int ordinalPosition; // ColumnSchema position in the table
     private int characterMaximumLength;

--- a/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
+++ b/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
@@ -114,6 +114,7 @@ public class ConverterTest {
     public void doubleCell() throws TableMapException {
         Cell c = new DoubleCell(1.5);
         ColumnSchema s = new ColumnSchema();
+        s.setColumnType("double");
 
         assertEquals("1.5", Converter.cellValueToString(c, s));
     }
@@ -126,7 +127,7 @@ public class ConverterTest {
 
         assertEquals("1.5", Converter.cellValueToString(c, s));
     }
-    
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // TIME AND DATE
 

--- a/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
+++ b/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
@@ -1,0 +1,106 @@
+package com.booking.replication.schema.column.types;
+
+import com.booking.replication.binlog.common.Cell;
+import com.booking.replication.binlog.common.cell.*;
+import com.booking.replication.schema.column.ColumnSchema;
+import com.booking.replication.schema.exception.TableMapException;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class ConverterTest {
+
+    // Variations of text cell schema
+    @Test
+    public void blobWithTextSchema() {
+        Cell textCell = new BlobCell(null);
+
+        // TODO: Add test
+    }
+
+    @Test
+    public void blobWithTinytextSchema() {
+        // TODO
+    }
+
+    @Test
+    public void blobWithMediumtextSchema() {
+        // TODO
+    }
+
+    @Test
+    public void blobWithLongtextSchema() {
+        // TODO
+    }
+
+    @Test
+    public void doubleCell() throws TableMapException {
+        Cell c = new DoubleCell(1.5);
+        ColumnSchema s = new ColumnSchema();
+
+        assertEquals("1.5", Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void floatCell() throws TableMapException {
+        Cell c = new FloatCell((float)1.5);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("float");
+
+        assertEquals("1.5", Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void datetimeCell() throws ParseException, TableMapException {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        Date d = sdf.parse("16/01/2018");
+        Cell c = new DatetimeCell(d);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("datetime");
+
+        assertEquals(d.toString(), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void datetime2Cell() throws ParseException, TableMapException {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        Date d = sdf.parse("16/01/2018");
+        Cell c = new Datetime2Cell(d);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("datetime");
+
+        assertEquals(d.toString(), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void stringToString() throws TableMapException {
+        String testString = "test";
+        Cell stringCell = StringCell.valueOf(testString.getBytes(StandardCharsets.UTF_8));
+        ColumnSchema stringSchema = new ColumnSchema();
+        stringSchema.setCharacterSetName("utf8");
+
+        assertEquals(testString, Converter.cellValueToString(stringCell, stringSchema));
+    }
+
+    @Test
+    public void nullToString() throws TableMapException {
+        Cell nullCell = NullCell.valueOf(0);
+        ColumnSchema emptySchema = new ColumnSchema();
+
+        assertEquals("NULL", Converter.cellValueToString(nullCell, emptySchema));
+    }
+
+    @Test(expected = Exception.class) // TODO: Specify exception type
+    public void doubleCellWithTextSchema() throws TableMapException {
+        Cell c = new DoubleCell(1.0);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("text");
+
+        Converter.cellValueToString(c, s);
+    }
+}

--- a/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
+++ b/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
@@ -158,9 +158,59 @@ public class ConverterTest {
         Date d = sdf.parse("16/01/2018");
         Cell c = new DatetimeCell(d);
         ColumnSchema s = new ColumnSchema();
-        s.setColumnType("datetime");
+        s.setColumnType("date");
 
         assertEquals(d.toString(), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void yearCell() throws TableMapException {
+        int year = 2018;
+        Cell c = YearCell.valueOf(year);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("year");
+
+        assertEquals(Integer.toString(year), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void timeCell() throws TableMapException {
+        long epoch = 1000000;
+        java.sql.Time time = new java.sql.Time(epoch);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("time");
+
+        assertEquals(Long.toString(epoch), Converter.cellValueToString(new TimeCell(time), s));
+    }
+
+    @Test
+    public void time2Cell() throws TableMapException {
+        long epoch = 555555;
+        java.sql.Time time = new java.sql.Time(epoch);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("time");
+
+        assertEquals(Long.toString(epoch), Converter.cellValueToString(new Time2Cell(time), s));
+    }
+
+    @Test
+    public void timestampCell() throws TableMapException {
+        long epoch = 666666;
+        java.sql.Timestamp t = new java.sql.Timestamp(epoch);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("timestamp");
+
+        assertEquals(Long.toString(epoch), Converter.cellValueToString(new TimestampCell(t), s));
+    }
+
+    @Test
+    public void timestamp2Cell() throws TableMapException {
+        long epoch = 777777;
+        java.sql.Timestamp t = new java.sql.Timestamp(epoch);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("timestamp");
+
+        assertEquals(Long.toString(epoch), Converter.cellValueToString(new Timestamp2Cell(t), s));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -190,7 +240,7 @@ public class ConverterTest {
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // STRING CELLS
-    
+
     @Test
     public void stringToString() throws TableMapException {
         String testString = "test";

--- a/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
+++ b/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
@@ -95,12 +95,12 @@ public class ConverterTest {
         assertEquals("NULL", Converter.cellValueToString(nullCell, emptySchema));
     }
 
-    @Test(expected = Exception.class) // TODO: Specify exception type
-    public void doubleCellWithTextSchema() throws TableMapException {
-        Cell c = new DoubleCell(1.0);
-        ColumnSchema s = new ColumnSchema();
-        s.setColumnType("text");
-
-        Converter.cellValueToString(c, s);
-    }
+//    @Test(expected = Exception.class) // TODO: Specify exception type
+//    public void doubleCellWithTextSchema() throws TableMapException {
+//        Cell c = new DoubleCell(1.0);
+//        ColumnSchema s = new ColumnSchema();
+//        s.setColumnType("text");
+//
+//        Converter.cellValueToString(c, s);
+//    }
 }

--- a/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
+++ b/src/test/java/com/booking/replication/schema/column/types/ConverterTest.java
@@ -15,28 +15,100 @@ import static org.junit.Assert.*;
 
 public class ConverterTest {
 
-    // Variations of text cell schema
-    @Test
-    public void blobWithTextSchema() {
-        Cell textCell = new BlobCell(null);
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // INTEGER CELLS
 
-        // TODO: Add test
+    @Test
+    public void tinyintSignedCell() throws TableMapException {
+        int x = -125; // inside single byte
+        Cell c = TinyCell.valueOf(x);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("tinyint");
+        s.setDataType("tinyint"); // TODO : Remove
+
+        assertEquals(Integer.toString(x), Converter.cellValueToString(c, s));
+    }
+
+    // TODO: Failing!!!
+//    @Test
+//    public void tinyintUnsignedCell() throws TableMapException {
+//        int x = 225; // inside single byte
+//        Cell c = TinyCell.valueOf(x);
+//        ColumnSchema s = new ColumnSchema();
+//        s.setColumnType("unsigned tinyint");
+//        s.setDataType("tinyint"); // TODO : Remove
+//
+//        assertEquals(Integer.toString(x), Converter.cellValueToString(c, s));
+//    }
+
+    @Test
+    public void smallintCell() throws TableMapException {
+        int x = -30000;
+        Cell c = ShortCell.valueOf(x);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("smallint");
+        s.setDataType("smallint"); // TODO: Remove
+
+        assertEquals(Integer.toString(x), Converter.cellValueToString(c, s));
     }
 
     @Test
-    public void blobWithTinytextSchema() {
+    public void smallintUnsignedCell() {
         // TODO
     }
 
     @Test
-    public void blobWithMediumtextSchema() {
+    public void mediumintCell() throws TableMapException {
+        int x = -2000000;
+        Cell c = Int24Cell.valueOf(x);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("mediumint");
+        s.setDataType("mediumint"); // TODO: Remove
+
+        assertEquals(Integer.toString(x), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void mediumintUnsignedCell() {
         // TODO
     }
 
     @Test
-    public void blobWithLongtextSchema() {
+    public void intCell() throws TableMapException {
+        int x = -2000000000;
+        Cell c = LongCell.valueOf(x);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("int");
+        s.setDataType("int");
+
+        assertEquals(Integer.toString(x), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void intUnsignedCell() {
         // TODO
     }
+
+    @Test
+    public void bigintCell() throws TableMapException {
+        long x = -9000000000000000000L;
+        Cell c = LongLongCell.valueOf(x);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("bigint");
+        s.setDataType("bigint");
+
+        assertEquals(Long.toString(x), Converter.cellValueToString(c, s));
+    }
+
+    @Test
+    public void bigintUnsignedCell() {
+        // TODO
+    }
+
+    // TODO : Add tests for overflows
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // REAL NUMBERS
 
     @Test
     public void doubleCell() throws TableMapException {
@@ -54,6 +126,9 @@ public class ConverterTest {
 
         assertEquals("1.5", Converter.cellValueToString(c, s));
     }
+    
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // TIME AND DATE
 
     @Test
     public void datetimeCell() throws ParseException, TableMapException {
@@ -78,6 +153,45 @@ public class ConverterTest {
     }
 
     @Test
+    public void dateCell() throws ParseException, TableMapException {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        Date d = sdf.parse("16/01/2018");
+        Cell c = new DatetimeCell(d);
+        ColumnSchema s = new ColumnSchema();
+        s.setColumnType("datetime");
+
+        assertEquals(d.toString(), Converter.cellValueToString(c, s));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // BLOB VARIATIONS
+
+    @Test
+    public void blobWithTextSchema() {
+        Cell textCell = new BlobCell(null);
+
+        // TODO: Add test
+    }
+
+    @Test
+    public void blobWithTinytextSchema() {
+        // TODO
+    }
+
+    @Test
+    public void blobWithMediumtextSchema() {
+        // TODO
+    }
+
+    @Test
+    public void blobWithLongtextSchema() {
+        // TODO
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // STRING CELLS
+    
+    @Test
     public void stringToString() throws TableMapException {
         String testString = "test";
         Cell stringCell = StringCell.valueOf(testString.getBytes(StandardCharsets.UTF_8));
@@ -87,6 +201,9 @@ public class ConverterTest {
         assertEquals(testString, Converter.cellValueToString(stringCell, stringSchema));
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // NULL
+    
     @Test
     public void nullToString() throws TableMapException {
         Cell nullCell = NullCell.valueOf(0);
@@ -94,6 +211,9 @@ public class ConverterTest {
 
         assertEquals("NULL", Converter.cellValueToString(nullCell, emptySchema));
     }
+    
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // CELL TYPE AND SCHEMA CONFLICTS
 
 //    @Test(expected = Exception.class) // TODO: Specify exception type
 //    public void doubleCellWithTextSchema() throws TableMapException {


### PR DESCRIPTION
1. Added basic unit tests for the `Converter` class;
2. Added `toString` conversion to several `Cell` subclasses. The conversion was absent and `Object.toString()` was called. This caused unit tests to fail.