### PR TITLE
Allow to write payload into HBase

### DIFF
--- a/src/main/java/com/booking/replication/Configuration.java
+++ b/src/main/java/com/booking/replication/Configuration.java
@@ -43,6 +43,13 @@ public class Configuration {
         public int          port        = 3306;
     }
 
+    @JsonDeserialize
+    private Payload payload;
+
+    private static class Payload implements Serializable {
+        public String table_name;
+    }
+
 
     @JsonDeserialize
     @JsonProperty("mysql_failover")
@@ -437,6 +444,13 @@ public class Configuration {
     @JsonIgnore
     public String getReplicantDBPassword() {
         return replication_schema.password;
+    }
+
+
+    // =========================================================================
+    // Payload config getters
+    public String getPayloadTableName() {
+        return payload.table_name;
     }
 
     // =========================================================================

--- a/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
+++ b/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
@@ -415,7 +415,7 @@ public class HBaseApplierMutationGenerator {
         if (row.getTransactionUUID() != null) {
             return row.getTransactionUUID().toString();
         } else {
-            return getHBaseRowKey(row);
+            throw new RuntimeException("Transaction ID missing in Augmented Row");
         }
     }
 

--- a/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
+++ b/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
@@ -121,6 +121,9 @@ public class HBaseApplierMutationGenerator {
 
         // RowID
         String hbaseRowID = getHBaseRowKey(row);
+        if (configuration.getPayloadTableName() != null && configuration.getPayloadTableName().equals(row.getTableName())) {
+            hbaseRowID = getPayloadTableHBaseRowKey(row);
+        }
 
         String hbaseTableName =
                 configuration.getHbaseNamespace() + ":" + row.getTableName().toLowerCase();
@@ -406,6 +409,15 @@ public class HBaseApplierMutationGenerator {
         // avoid region hot-spotting
         hbaseRowID = saltRowKey(hbaseRowID, saltingPartOfKey);
         return hbaseRowID;
+    }
+
+    private static String getPayloadTableHBaseRowKey(AugmentedRow row) {
+        if (row.getTransactionUUID() != null) {
+            String uuid = row.getTransactionUUID().toString();
+            return saltRowKey(uuid, uuid);
+        } else {
+            return getHBaseRowKey(row);
+        }
     }
 
     /**

--- a/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
+++ b/src/main/java/com/booking/replication/applier/hbase/HBaseApplierMutationGenerator.java
@@ -413,8 +413,7 @@ public class HBaseApplierMutationGenerator {
 
     private static String getPayloadTableHBaseRowKey(AugmentedRow row) {
         if (row.getTransactionUUID() != null) {
-            String uuid = row.getTransactionUUID().toString();
-            return saltRowKey(uuid, uuid);
+            return row.getTransactionUUID().toString();
         } else {
             return getHBaseRowKey(row);
         }


### PR DESCRIPTION
Idea is that for some setups it would be interesting to know in which context some event happened (server, author etc)
Approach implemented works in a way with special payload table.
Additional table is created in source mysql schema. It is suggested table would be blackhole mysql engine to avoid performance penalty. During transactions client makes writes into table to set payload information like "insert into __payload__ set author='boss' and 'server='backoffice-xx'". These writes will be ignored by mysql but written into backlog.

When turned on in configuration replicator will form keys to table from transaction uuid instead of primary key.
When data is read from HBase one can retrieve transaction uuid together. And by transaction id one can retrieve payload.