### PR TITLE
Bdevetak/fixes

### DIFF
--- a/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/Augmenter.java
+++ b/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/Augmenter.java
@@ -90,6 +90,7 @@ public class Augmenter implements Function<RawEvent, Collection<AugmentedEvent>>
 
     public interface Configuration {
         String SCHEMA_TYPE = "augmenter.schema.type";
+        String BOOTSTRAP = "augmenter.schema.bootstrap";
     }
 
     private final AugmenterContext context;
@@ -118,7 +119,9 @@ public class Augmenter implements Function<RawEvent, Collection<AugmentedEvent>>
             this.context.updateContext(eventHeader, eventData);
 
             if (this.context.shouldProcess()) {
+
                 if(this.context.isTransactionsEnabled()){
+
                     return processTransactionFlow(eventHeader, eventData);
                 }
                 AugmentedEvent augmentedEvent = getAugmentedEvent(eventHeader, eventData);
@@ -167,11 +170,9 @@ public class Augmenter implements Function<RawEvent, Collection<AugmentedEvent>>
                     Collection<AugmentedEvent> augmentedEvents = this.context.getTransaction().getAndClear();
 
                     this.context.getTransaction().add(augmentedEvent);
-
                     return augmentedEvents;
                 } else {
                     this.context.getTransaction().add(augmentedEvent);
-
                     return null;
                 }
             } else {

--- a/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/AugmenterContext.java
+++ b/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/AugmenterContext.java
@@ -96,7 +96,6 @@ public class AugmenterContext implements Closeable {
 
     private final AtomicReference<String> binlogFilename;
     private final AtomicLong binlogPosition;
-    private final AtomicReference<String> currentTransactionSchemaName;
 
     private final GTIDType gtidType;
     private final AtomicReference<String> gtidValue;
@@ -177,7 +176,6 @@ public class AugmenterContext implements Closeable {
 
         this.isAtDDL = new AtomicBoolean();
         this.isAtDDL.set(false);
-        currentTransactionSchemaName = new AtomicReference<>();
         replicatedSchema = (String) configuration.get( BinaryLogSupplier.Configuration.MYSQL_SCHEMA );
 
     }
@@ -257,7 +255,6 @@ public class AugmenterContext implements Closeable {
 
                 // begin
                 if (this.beginPattern.matcher(query).find()) {
-                    currentTransactionSchemaName.set(queryRawEventData.getDatabase());
                     this.updateCommons(
                             false,
                             QueryAugmentedEventDataType.BEGIN,
@@ -474,7 +471,7 @@ public class AugmenterContext implements Closeable {
                     tblName = eventTable.getName();
                 }
                 this.updateCommons(
-                        ( currentTransactionSchemaName.get().equals(replicatedSchema) ) && ((eventTable == null) || (!this.excludeTable(eventTable.getName()))),
+                        ( (eventTable == null) || (!this.excludeTable(eventTable.getName())) ),
                         null,
                         null,
                         dbName,

--- a/mysql-replicator-streams/src/main/java/com/booking/replication/streams/StreamsImplementation.java
+++ b/mysql-replicator-streams/src/main/java/com/booking/replication/streams/StreamsImplementation.java
@@ -216,18 +216,15 @@ public final class StreamsImplementation<Input, Output> implements Streams<Input
         // by queue poller.
         else if (this.queues != null) {
 
-            LOG.info("Push: queue exists");
             Objects.requireNonNull(this.queues, "queues must not be null");
 
             if (!this.running.get()) {
                 throw new IllegalStateException("Streams has stopped.");
             }
 
-            LOG.info("Push: stream still running");
-
             try {
                 if (!StreamsImplementation.this.queues[this.partitioner.apply(input, this.tasks)].offer(input, this.queueTimeout, TimeUnit.SECONDS)) {
-                    LOG.info("Push: offer timeout");
+                    LOG.warning("Push: offer timeout");
                     this.handleException(new StreamsException(String.format("Max waiting time exceeded while writing setSink internal buffer: %d", this.queueTimeout)));
                 }
             } catch (InterruptedException exception) {

--- a/mysql-replicator/src/main/java/com/booking/utils/BootstrapReplicator.java
+++ b/mysql-replicator/src/main/java/com/booking/utils/BootstrapReplicator.java
@@ -3,6 +3,7 @@ package com.booking.utils;
 import com.booking.replication.applier.kafka.KafkaApplier;
 import com.booking.replication.applier.schema.registry.BCachedSchemaRegistryClient;
 import com.booking.replication.augmenter.ActiveSchemaManager;
+import com.booking.replication.augmenter.Augmenter;
 import com.booking.replication.augmenter.model.event.format.avro.EventDataPresenterAvro;
 import com.booking.replication.augmenter.model.schema.ColumnSchema;
 import com.booking.replication.augmenter.model.schema.FullTableName;
@@ -31,6 +32,11 @@ public class BootstrapReplicator {
     }
 
     public void run() {
+
+        if ((boolean) configuration.get(Augmenter.Configuration.BOOTSTRAP) == false) {
+            LOG.log(Level.INFO, "Skipping active schema bootstrapping");
+            return;
+        }
         LOG.log(Level.INFO, "Running bootstrapping");
 
         ActiveSchemaManager activeSchemaManager = new ActiveSchemaManager(configuration);
@@ -76,8 +82,5 @@ public class BootstrapReplicator {
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Error while bootstrapping", e);
         }
-
-
     }
-
 }

--- a/mysql-replicator/src/test/java/com/booking/utils/BootstrapReplicatorTest.java
+++ b/mysql-replicator/src/test/java/com/booking/utils/BootstrapReplicatorTest.java
@@ -4,6 +4,7 @@ package com.booking.utils;
 import com.booking.replication.applier.kafka.KafkaApplier;
 import com.booking.replication.applier.schema.registry.BCachedSchemaRegistryClient;
 import com.booking.replication.augmenter.ActiveSchemaManager;
+import com.booking.replication.augmenter.Augmenter;
 import com.booking.replication.commons.services.ServicesControl;
 import com.booking.replication.commons.services.ServicesProvider;
 import com.booking.replication.supplier.mysql.binlog.BinaryLogSupplier;
@@ -24,6 +25,7 @@ public class BootstrapReplicatorTest {
     private static final String KAFKA_REPLICATOR_TOPIC_NAME = "mytopic";
     private static final String MYSQL_INIT_SCRIPT = "mysql.init.sql";
     private static final String MYSQL_ROOT_USERNAME = "root";
+    private static final boolean BOOTSTRAP_ACTIVE = true;
     private static ServicesControl mysqlBinaryLog;
     private static ServicesControl mysqlActiveSchema;
     private static ServicesControl kafkaZk;
@@ -59,6 +61,7 @@ public class BootstrapReplicatorTest {
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_SCHEMA, BootstrapReplicatorTest.MYSQL_ACTIVE_SCHEMA);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_USERNAME, BootstrapReplicatorTest.MYSQL_ROOT_USERNAME);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PASSWORD, BootstrapReplicatorTest.MYSQL_PASSWORD);
+        configuration.put(Augmenter.Configuration.BOOTSTRAP, BootstrapReplicatorTest.BOOTSTRAP_ACTIVE);
 
         String schemaRegistryUrl = String.format("http://%s:%d", BootstrapReplicatorTest.schemaRegistry.getHost(), BootstrapReplicatorTest.schemaRegistry.getPort());
         configuration.put(KafkaApplier.Configuration.SCHEMA_REGISTRY_URL, schemaRegistryUrl);


### PR DESCRIPTION
This branch includes the following changes:

1. Add a configuration variable **augmenter.schema.bootstrap** which accepts a boolean value to determine whether or not we need to bootstrap the active schema
2. Added a fix for BlockingQueues not really being blocking when polling (which caused the app to eat 100% CPU on all cores)
3. Removed logic around **currentTransactionSchemaName**, this circumvents the issue discovered in the hackathon re: QueryEvent messages (specifically BEGIN statements) are no longer guaranteed to contain schema name
4. Cleaned up some logging