### PR TITLE
Remove hardcoded Apache Avro from the codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 dependency-reduced-pom.xml
 target
 
-# Avoid including generated files in GIT
-mysql-replicator-augmenter-model/src/main/java/replicator/
+# Avoid including generated definitions in git
+mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/definitions/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .idea/
 dependency-reduced-pom.xml
 target
+
+# Avoid including generated files in GIT
+mysql-replicator-augmenter-model/src/main/java/replicator/

--- a/mysql-replicator-augmenter-model/pom.xml
+++ b/mysql-replicator-augmenter-model/pom.xml
@@ -17,4 +17,34 @@
             <artifactId>mysql-replicator-commons</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/avro/</sourceDirectory>
+                            <outputDirectory>${project.basedir}/src/main/java/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/mysql-replicator-augmenter-model/src/main/avro/DDL.avsc
+++ b/mysql-replicator-augmenter-model/src/main/avro/DDL.avsc
@@ -1,7 +1,7 @@
 {
 	"type": "record",
-	"name": "ddl",
-	"namespace": "replicator",
+	"name": "DDL",
+	"namespace": "com.booking.replication.augmenter.model.definitions",
 	"fields": [{
 			"name": "query",
 			"type": [

--- a/mysql-replicator-augmenter-model/src/main/avro/ddl.avsc
+++ b/mysql-replicator-augmenter-model/src/main/avro/ddl.avsc
@@ -1,0 +1,30 @@
+{
+	"type": "record",
+	"name": "ddl",
+	"namespace": "replicator",
+	"fields": [{
+			"name": "query",
+			"type": [
+				"null",
+				"string"
+			],
+			"default": null
+		},
+		{
+			"name": "schema",
+			"type": [
+				"null",
+				"string"
+			],
+			"default": null
+		},
+		{
+			"name": "isCompatibleSchemaChange",
+			"type": [
+				"null",
+				"boolean"
+			],
+			"default": null
+		}
+	]
+}

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/format/avro/EventDataPresenterAvro.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/format/avro/EventDataPresenterAvro.java
@@ -1,5 +1,6 @@
 package com.booking.replication.augmenter.model.event.format.avro;
 
+import com.booking.replication.augmenter.model.definitions.DDL;
 import com.booking.replication.augmenter.model.event.*;
 import com.booking.replication.augmenter.model.row.AugmentedRow;
 import com.booking.replication.augmenter.model.schema.ColumnSchema;
@@ -16,7 +17,6 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import replicator.ddl;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -98,7 +98,7 @@ public class EventDataPresenterAvro {
         try {
             Schema avroSchema = createAvroSchema(ADD_META_FILEDS, CONVERT_BIN_TO_HEX, this.eventTable, this.columns);
             if (Objects.equals(this.eventType, "ddl")) {
-                final GenericRecord rec = new ddl(
+                final GenericRecord rec = new DDL(
                         this.sql,
                         avroSchema.toString(),
                         this.isCompatibleSchemaChange

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/format/avro/EventDataPresenterAvro.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/format/avro/EventDataPresenterAvro.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
@@ -17,6 +16,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import replicator.ddl;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,43 +28,11 @@ public class EventDataPresenterAvro {
 
     private static final boolean CONVERT_BIN_TO_HEX = true;
     private static final boolean ADD_META_FILEDS = true;
-    private static final String DDL_SCHEMA = "{\n" +
-            "  \"type\": \"record\",\n" +
-            "  \"name\": \"ddl\",\n" +
-            "  \"namespace\": \"replicator\",\n" +
-            "  \"fields\": [\n" +
-            "    {\n" +
-            "      \"name\": \"query\",\n" +
-            "      \"type\": [\n" +
-            "        \"null\",\n" +
-            "        \"string\"\n" +
-            "      ],\n" +
-            "      \"default\": null\n" +
-            "    },\n" +
-            "    {\n" +
-            "      \"name\": \"schema\",\n" +
-            "      \"type\": [\n" +
-            "        \"null\",\n" +
-            "        \"string\"\n" +
-            "      ],\n" +
-            "      \"default\": null\n" +
-            "    },\n" +
-            "    {\n" +
-            "      \"name\": \"isCompatibleSchemaChange\",\n" +
-            "      \"type\": [\n" +
-            "        \"null\",\n" +
-            "        \"boolean\"\n" +
-            "      ],\n" +
-            "      \"default\": null\n" +
-            "    }\n" +
-            "  ]\n" +
-            "}";
 
     private Collection<ColumnSchema> columns;
     private Collection<AugmentedRow> rows;
     private FullTableName eventTable;
     private AugmentedEventHeader header;
-    boolean useLogicalTypes = false;
     private String eventType;
     private String sql;
     private boolean skipRow;
@@ -129,14 +97,12 @@ public class EventDataPresenterAvro {
         if (this.skipRow) return new ArrayList<>();
         try {
             Schema avroSchema = createAvroSchema(ADD_META_FILEDS, CONVERT_BIN_TO_HEX, this.eventTable, this.columns);
-
             if (Objects.equals(this.eventType, "ddl")) {
-                Schema.Parser parser = new Schema.Parser();
-                Schema schema = parser.parse(DDL_SCHEMA);
-                final GenericRecord rec = new GenericData.Record(schema);
-                rec.put("query", this.sql);
-                rec.put("schema", avroSchema.toString());
-                rec.put("isCompatibleSchemaChange", this.isCompatibleSchemaChange);
+                final GenericRecord rec = new ddl(
+                        this.sql,
+                        avroSchema.toString(),
+                        this.isCompatibleSchemaChange
+                );
                 return Collections.singletonList(rec);
             }
             ArrayList<GenericRecord> records = new ArrayList<>();


### PR DESCRIPTION
We should always generate the Apache Avro definitions. This has several advantages:

- **More performant** we do less on runtime, such as inferring and constructing the schema from the JSON definition.
- **Less error prone** because the compiler will check if the fields match