### PR TITLE
Saurigema/osc related fixes

### DIFF
--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/FullTableName.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/FullTableName.java
@@ -20,7 +20,7 @@ public class FullTableName implements Serializable {
         if(name == null) return name;
         name = name.replaceAll("`", "");
         if ( name.contains(".") ) {
-            return name.split(".")[1];
+            return name.split("\\.")[1];
         }
         return name;
     }

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/FullTableName.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/FullTableName.java
@@ -18,7 +18,11 @@ public class FullTableName implements Serializable {
 
     private String cleaned(String name) {
         if(name == null) return name;
-        return name.replaceAll("`", "");
+        name = name.replaceAll("`", "");
+        if ( name.contains(".") ) {
+            return name.split(".")[1];
+        }
+        return name;
     }
 
     public String getDatabase() {

--- a/mysql-replicator-supplier/src/main/java/com/booking/replication/supplier/mysql/binlog/BinaryLogSupplier.java
+++ b/mysql-replicator-supplier/src/main/java/com/booking/replication/supplier/mysql/binlog/BinaryLogSupplier.java
@@ -9,10 +9,7 @@ import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -197,6 +194,8 @@ public class BinaryLogSupplier implements Supplier {
                             );
 
                         }
+
+                        this.client.setServerId(new Random().nextLong() );
 
                         if (checkpoint != null) {
                             if (checkpoint.getGtidSet() != null && !checkpoint.getGtidSet().equals("")) {

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <jackson.version>2.9.8</jackson.version>
         <zookeeper.version>3.4.12</zookeeper.version>
         <curator.version>4.0.1</curator.version>
-        <mysql-connector.version>5.1.46</mysql-connector.version>
+        <mysql-connector.version>5.1.47</mysql-connector.version>
         <mysql-binlog-connector.version>0.16.1</mysql-binlog-connector.version>
         <commons-dbcp2.version>2.4.0</commons-dbcp2.version>
         <kafka.version>1.1.0</kafka.version>


### PR DESCRIPTION
Changes created during debugging of an OSC related issue. Includes:

1. Randomly sets serverID when initiating the binlogSupplier connection, this prevents warnings/errors from running multiple replicators on a single host/when restarting a single replicator too quickly (done because we kept seeing these warnings when doing debugging)
2. Additional step in cleaning up the FullTableName from events to strip the schema if it's present. Added as we came across an instance where the tableName contained a schema.
3. Bumped the build version of the MySQL connector, this was done to try and eliminate JDBC as a potential source of problems. Attempts were made to increase the major version number but unfortunately the current version ( 5.1.47 ) is the last version which supports CEST.
4. Replace the previous usages of excludeTable and includeTable with a shouldProcessTable function which hides the underlying logic (and simplifies the callsites). Additionally included this check for DDL TABLE events to prevent us from processing events for tables which we are not interested in.