### PR TITLE
v016-RC2 release

### DIFF
--- a/mysql-replicator-applier/pom.xml
+++ b/mysql-replicator-applier/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-applier</artifactId>
     <name>mysql-replicator-applier</name>

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/HBaseApplier.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/HBaseApplier.java
@@ -197,12 +197,12 @@ public class HBaseApplier implements Applier {
 
         this.metrics
                 .getRegistry()
-                .histogram("hbase.thread_" + threadID + ".applier.events.apply.batchsize")
+                .histogram("applier.hbase.thread_" + threadID + ".events.apply.batchsize")
                 .update(events.size());
 
         for (AugmentedEvent event : events) {
             this.metrics.getRegistry()
-                    .counter("hbase.thread_" + threadID + ".applier.events.seen").inc(1L);
+                    .counter("applier.hbase.thread_" + threadID + ".events.seen").inc(1L);
         }
 
         if (dryRun) {
@@ -240,23 +240,23 @@ public class HBaseApplier implements Applier {
             if ((dataEvents.size() >= FLUSH_BUFFER_SIZE) || hbaseApplierWriter.getThreadBufferSize(threadID) >= FLUSH_BUFFER_SIZE) {
                 hbaseApplierWriter.buffer(threadID, transactionUUID, dataEvents);
                 this.metrics.getRegistry()
-                        .counter("hbase.thread_" + threadID + ".applier.buffer.buffered").inc(1L);
+                        .counter("applier.hbase.thread_" + threadID + ".buffer.buffered").inc(1L);
                 this.metrics.getRegistry()
-                        .counter("hbase.thread_" + threadID + ".applier.buffer.flush.attempt").inc(1L);
+                        .counter("applier.hbase.thread_" + threadID + ".buffer.flush.attempt").inc(1L);
                 boolean isFlushSuccess = hbaseApplierWriter.flushThreadBuffer(threadID);
 
                 if (isFlushSuccess) {
                     this.metrics.getRegistry()
-                            .counter("thread_" + threadID + ".hbase_applier.buffer.flush.success").inc(1L);
+                            .counter("applier.hbase.thread_" + threadID + ".buffer.flush.success").inc(1L);
                     return true; // <- committed, will advance safe checkpoint
                 } else {
                     this.metrics.getRegistry()
-                            .counter("thread_" + threadID + ".hbase_applier.buffer.flush.failure").inc(1L);
+                            .counter("applier.hbase.thread_" + threadID + ".buffer.flush.failure").inc(1L);
                     throw new RuntimeException("Failed to write buffer to HBase");
                 }
             } else {
                 this.metrics.getRegistry()
-                        .counter("thread_" + threadID + ".hbase_applier.buffer.buffered").inc(1L);
+                        .counter("applier.hbase.thread_" + threadID + ".buffer.buffered").inc(1L);
                 hbaseApplierWriter.buffer(threadID, transactionUUID, dataEvents);
                 return false; // buffered
             }
@@ -266,17 +266,17 @@ public class HBaseApplier implements Applier {
             for (String transactionUUID : transactionUUIDs) {
                 hbaseApplierWriter.buffer(threadID, transactionUUID, dataEvents);
                 this.metrics.getRegistry()
-                        .counter("thread_" + threadID + ".hbase_applier.buffer.buffered").inc(1L);
+                        .counter("applier.hbase.thread_" + threadID + ".buffer.buffered").inc(1L);
             }
             this.metrics.getRegistry()
-                    .counter("thread_" + threadID + ".hbase_applier.buffer.flush.force.attempt").inc(1L);
+                    .counter("applier.hbase.thread_" + threadID + ".buffer.flush.force.attempt").inc(1L);
             forceFlush();
             this.metrics.getRegistry()
-                    .counter("thread_" + threadID + ".hbase_applier.buffer.flush.force.success").inc(1L);
+                    .counter("applier.hbase.thread_" + threadID + ".buffer.flush.force.success").inc(1L);
             return true;
         } else {
             this.metrics.getRegistry()
-                    .counter("thread_" + threadID + ".hbase_applier.events.empty").inc(1L);
+                    .counter("applier.hbase.thread_" + threadID + ".events.empty").inc(1L);
             return false; // treat empty transaction as buffered
         }
     }

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/mutation/HBaseApplierMutationGenerator.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/mutation/HBaseApplierMutationGenerator.java
@@ -134,9 +134,9 @@ public class HBaseApplierMutationGenerator {
                         Bytes.toBytes(columnValue)
                 );
                 this.metrics.getRegistry()
-                        .counter("hbase.applier.columns.mutations.count").inc(1L);
+                        .counter("applier.hbase.columns.mutations.count").inc(1L);
                 this.metrics.getRegistry()
-                        .counter("hbase.applier.columns.mutations.delete.count").inc(1L);
+                        .counter("applier.hbase.columns.mutations.delete.count").inc(1L);
 
                 if (uuid != null) {
                     put.addColumn(
@@ -147,9 +147,9 @@ public class HBaseApplierMutationGenerator {
                     );
 
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.delete.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.delete.count").inc(1L);
                 }
                 if (xid != null) {
                     put.addColumn(
@@ -160,9 +160,9 @@ public class HBaseApplierMutationGenerator {
                     );
 
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.delete.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.delete.count").inc(1L);
                 }
                 break;
             }
@@ -194,9 +194,9 @@ public class HBaseApplierMutationGenerator {
                         );
 
                         this.metrics.getRegistry()
-                                .counter("hbase.applier.columns.mutations.count").inc(1L);
+                                .counter("applier.hbase.columns.mutations.count").inc(1L);
                         this.metrics.getRegistry()
-                                .counter("hbase.applier.columns.mutations.update.count").inc(1L);
+                                .counter("applier.hbase.columns.mutations.update.count").inc(1L);
 
                     } else {
                         // no change, skip
@@ -210,9 +210,9 @@ public class HBaseApplierMutationGenerator {
                         Bytes.toBytes("U")
                 );
                 this.metrics.getRegistry()
-                        .counter("hbase.applier.columns.mutations.count").inc(1L);
+                        .counter("applier.hbase.columns.mutations.count").inc(1L);
                 this.metrics.getRegistry()
-                        .counter("hbase.applier.columns.mutations.update.count").inc(1L);
+                        .counter("applier.hbase.columns.mutations.update.count").inc(1L);
 
                 if (uuid != null) {
                     put.addColumn(
@@ -222,9 +222,9 @@ public class HBaseApplierMutationGenerator {
                             Bytes.toBytes(uuid)
                     );
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.update.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.update.count").inc(1L);
                 }
 
                 if (xid != null) {
@@ -235,9 +235,9 @@ public class HBaseApplierMutationGenerator {
                             Bytes.toBytes(xid.toString())
                     );
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.update.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.update.count").inc(1L);
                 }
                 break;
             }
@@ -259,9 +259,9 @@ public class HBaseApplierMutationGenerator {
                     );
 
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.insert.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.insert.count").inc(1L);
                 }
 
                 put.addColumn(
@@ -272,9 +272,9 @@ public class HBaseApplierMutationGenerator {
                 );
 
                 this.metrics.getRegistry()
-                        .counter("hbase.applier.columns.mutations.count").inc(1L);
+                        .counter("applier.hbase.columns.mutations.count").inc(1L);
                 this.metrics.getRegistry()
-                        .counter("hbase.applier.columns.mutations.insert.count").inc(1L);
+                        .counter("applier.hbase.columns.mutations.insert.count").inc(1L);
 
                 if (uuid != null) {
                     put.addColumn(
@@ -284,9 +284,9 @@ public class HBaseApplierMutationGenerator {
                             Bytes.toBytes(uuid)
                     );
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.insert.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.insert.count").inc(1L);
                 }
 
                 if (xid != null) {
@@ -297,9 +297,9 @@ public class HBaseApplierMutationGenerator {
                             Bytes.toBytes(xid.toString())
                     );
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.count").inc(1L);
                     this.metrics.getRegistry()
-                            .counter("hbase.applier.columns.mutations.insert.count").inc(1L);
+                            .counter("applier.hbase.columns.mutations.insert.count").inc(1L);
                 }
                 break;
             }

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/writer/HBaseTimeMachineWriter.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/writer/HBaseTimeMachineWriter.java
@@ -61,10 +61,10 @@ public class HBaseTimeMachineWriter implements HBaseApplierWriter {
         this.hbaseSchemaManager = hbaseSchemaManager;
 
         this.metrics.getRegistry()
-                .counter("hbase.applier.connection.attempt").inc(1L);
+                .counter("applier.hbase.connection.attempt").inc(1L);
         connection = ConnectionFactory.createConnection(hbaseConfig);
         this.metrics.getRegistry()
-                .counter("hbase.applier.connection.success").inc(1L);
+                .counter("applier.hbase.connection.success").inc(1L);
 
         admin = connection.getAdmin();
 
@@ -192,7 +192,7 @@ public class HBaseTimeMachineWriter implements HBaseApplierWriter {
     private void writeToHBase(Long threadID) throws IOException {
 
         this.metrics.getRegistry()
-                .histogram("hbase.thread_" + threadID + "_applier.writer.buffer.thread_" + threadID + ".nr_transactions_buffered")
+                .histogram("applier.hbase.writer.buffer.thread_" + threadID + ".nr_transactions_buffered")
                 .update( buffered.get(threadID).size() );
 
         List<HBaseApplierMutationGenerator.PutMutation> mutations = new ArrayList<>();
@@ -206,7 +206,7 @@ public class HBaseTimeMachineWriter implements HBaseApplierWriter {
                 hbaseSchemaManager.createHBaseTableIfNotExists(augmentedRowsTableName);
 
                 this.metrics.getRegistry()
-                        .counter("hbase.thread_" + threadID + ".applier.writer.rows.received").inc(augmentedRows.size());
+                        .counter("applier.hbase.writer.thread_" + threadID + ".rows.received").inc(augmentedRows.size());
 
                 if (timestampOrganizer != null) {
                     timestampOrganizer.organizeTimestamps(augmentedRows, augmentedRowsTableName, threadID, transactionUUID);
@@ -218,7 +218,7 @@ public class HBaseTimeMachineWriter implements HBaseApplierWriter {
                 mutations.addAll(eventMutations);
 
                 this.metrics.getRegistry()
-                        .counter("hbase.thread_" + threadID + ".applier.writer.mutations_generated").inc(eventMutations.size());
+                        .counter("applier.hbase.writer.thread_" + threadID + ".mutations_generated").inc(eventMutations.size());
 
             }
         }
@@ -255,12 +255,12 @@ public class HBaseTimeMachineWriter implements HBaseApplierWriter {
 
             this.metrics
                     .getRegistry()
-                    .histogram("hbase.thread_" + threadID + ".applier.writer.put.latency")
+                    .histogram("applier.writer.hbase.thread_" + threadID + ".put.latency")
                     .update(latency);
 
             this.metrics
                     .getRegistry()
-                    .histogram("hbase.thread_" + threadID + ".applier.writer.put.nr-mutations")
+                    .histogram("applier.writer.hbase.thread_" + threadID + ".put.nr-mutations")
                     .update(nrMutations);
 
             // TODO: send sample to validator

--- a/mysql-replicator-augmenter-model/pom.xml
+++ b/mysql-replicator-augmenter-model/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>replicator</artifactId>
         <groupId>com.booking.replication</groupId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-augmenter-model</artifactId>
     <name>mysql-replicator-augmenter-model</name>

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/AugmentedEventHeader.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/AugmentedEventHeader.java
@@ -72,6 +72,18 @@ public class AugmentedEventHeader implements Serializable {
         return String.format("%s-%s-%s", this.databaseName, this.tableName, timestamp);
     }
 
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void setCheckpoint(Checkpoint checkpoint) {
+        this.checkpoint = checkpoint;
+    }
+
+    public void setEventType(AugmentedEventType eventType) {
+        this.eventType = eventType;
+    }
+
     @Override
     public String toString() {
         return String.format("timestamp: %s | checkpoint: %s | eventType: %s | db: %s | table: %s", timestamp, checkpoint.toString(), eventType, databaseName, tableName);

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/AugmentedEventTransaction.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/AugmentedEventTransaction.java
@@ -5,10 +5,14 @@ import java.io.Serializable;
 @SuppressWarnings("unused")
 public class AugmentedEventTransaction implements Serializable, Comparable<AugmentedEventTransaction> {
 
-    private final long commitTimestamp;
-    private final String identifier;
-    private final long xxid;
-    private final long transactionSequenceNumber;
+    private long commitTimestamp;
+    private String identifier;
+    private long xxid;
+    private long transactionSequenceNumber;
+
+    public AugmentedEventTransaction() {
+
+    }
 
     public AugmentedEventTransaction(long commitTimestamp, String identifier, long xxid, long transactionSequenceNumber) {
         this.commitTimestamp = commitTimestamp;
@@ -53,6 +57,22 @@ public class AugmentedEventTransaction implements Serializable, Comparable<Augme
         } else {
             return Integer.MAX_VALUE;
         }
+    }
+
+    public void setCommitTimestamp(long commitTimestamp) {
+        this.commitTimestamp = commitTimestamp;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public void setXxid(long xxid) {
+        this.xxid = xxid;
+    }
+
+    public void setTransactionSequenceNumber(long transactionSequenceNumber) {
+        this.transactionSequenceNumber = transactionSequenceNumber;
     }
 
     @Override

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/EventMetadata.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/EventMetadata.java
@@ -3,8 +3,13 @@ package com.booking.replication.augmenter.model.event;
 import com.booking.replication.augmenter.model.schema.FullTableName;
 
 public class EventMetadata {
+
     private FullTableName eventTable;
     private AugmentedEventType eventType;
+
+    public  EventMetadata() {
+
+    }
 
     public EventMetadata(FullTableName eventTable, AugmentedEventType eventType) {
         this.eventTable = eventTable;
@@ -17,5 +22,13 @@ public class EventMetadata {
 
     public AugmentedEventType getEventType() {
         return this.eventType;
+    }
+
+    public void setEventTable(FullTableName eventTable) {
+        this.eventTable = eventTable;
+    }
+
+    public void setEventType(AugmentedEventType eventType) {
+        this.eventType = eventType;
     }
 }

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/RowEventMetadata.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/RowEventMetadata.java
@@ -12,6 +12,10 @@ public class RowEventMetadata extends EventMetadata {
     private Collection<ColumnSchema> columns;
     private List<String> primaryKeyColumns;
 
+    public RowEventMetadata() {
+
+    }
+
     public RowEventMetadata(FullTableName eventTable, AugmentedEventType eventType, Collection<ColumnSchema> columns) {
         super(eventTable, eventType);
         this.columns    = columns;
@@ -27,4 +31,11 @@ public class RowEventMetadata extends EventMetadata {
         return this.primaryKeyColumns;
     }
 
+    public void setColumns(Collection<ColumnSchema> columns) {
+        this.columns = columns;
+    }
+
+    public void setPrimaryKeyColumns(List<String> primaryKeyColumns) {
+        this.primaryKeyColumns = primaryKeyColumns;
+    }
 }

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/RowsAugmentedEventData.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/RowsAugmentedEventData.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 
 public abstract class RowsAugmentedEventData implements TableAugmentedEventData {
 
-    protected EventMetadata metadata;
+    protected RowEventMetadata metadata;
 
     protected Collection<Boolean> includedColumns;
     protected Collection<AugmentedRow> rows;
@@ -36,7 +36,21 @@ public abstract class RowsAugmentedEventData implements TableAugmentedEventData 
         return this.rows;
     }
 
-    public EventMetadata getMetadata() {
+    public RowEventMetadata getMetadata() {
         return this.metadata;
     }
+
+    public void setMetadata(RowEventMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public void setIncludedColumns(Collection<Boolean> includedColumns) {
+        this.includedColumns = includedColumns;
+    }
+
+    public void setRows(Collection<AugmentedRow> rows) {
+        this.rows = rows;
+    }
+
+
 }

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/WriteRowsAugmentedEventData.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/event/WriteRowsAugmentedEventData.java
@@ -20,4 +20,6 @@ public class WriteRowsAugmentedEventData extends RowsAugmentedEventData {
     ) {
         super(eventType, eventTable, includedColumns, columns, augmentedRows);
     }
+
+
 }

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/format/EventDeserializer.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/format/EventDeserializer.java
@@ -64,6 +64,13 @@ public class EventDeserializer {
                                                    BitSet includedColumns,
                                                    Map<String, String[]> cache,
                                                    Serializable[] rowByteSlices) {
+        // require binlog_row_image=full at all times
+        // if during replication this config is changed, this condition will
+        // detect this and replicator will exit.
+        if (includedColumns.length() != columns.size()) {
+            throw new RuntimeException("Severe environment error: binlog_row_image variable is not set to FULL. Cannot continue replication.");
+        }
+
         for (int columnIndex = 0, rowIndex = 0; columnIndex < columns.size() && rowIndex < rowByteSlices.length; columnIndex++) {
 
             if (includedColumns.get(columnIndex)) {

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/row/AugmentedRow.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/row/AugmentedRow.java
@@ -147,6 +147,25 @@ public class AugmentedRow {
         }
     }
 
+    public void setTransactionUUID(String transactionUUID) {
+        this.transactionUUID = transactionUUID;
+    }
+
+    public void setPrimaryKeyColumns(List<String> primaryKeyColumns) {
+        this.primaryKeyColumns = primaryKeyColumns;
+    }
+
+    public void setEventType(AugmentedEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public void setTableSchema(String tableSchema) {
+        this.tableSchema = tableSchema;
+    }
+
+    public void setValues(Map<String, Object> values) {
+        this.values = values;
+    }
 
     @Override
     public String toString() {

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/FullTableName.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/FullTableName.java
@@ -41,6 +41,10 @@ public class FullTableName implements Serializable {
         this.name = tableName;
     }
 
+    public void setDb(String db) {
+        this.db = db;
+    }
+
     @Override
     public String toString() {
         return String.format("%s.%s", this.db, this.name);

--- a/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/SchemaTransitionSequence.java
+++ b/mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/schema/SchemaTransitionSequence.java
@@ -26,7 +26,7 @@ public class SchemaTransitionSequence {
 
         this.schemaTransitionTimestamp = new Long(schemaTransitionTimestamp);
 
-        if (columnsBefore.get() != null) { // <- null if table was just created
+        if (columnsBefore.get() != null && createTableBefore.get() != null) { // <- null if table was just created
             this.tableSchemaBefore = new TableSchema(
                     this.tableName,
                     columnsBefore.get().stream().map(c -> c.deepCopy()).collect(Collectors.toList()),
@@ -36,7 +36,7 @@ public class SchemaTransitionSequence {
             this.tableSchemaBefore = null;
         }
 
-        if (columnsAfter.get() != null) { // <- null if table was dropped
+        if (columnsAfter.get() != null && createTableAfter.get() != null) { // <- null if table was dropped
             this.tableSchemaAfter = new TableSchema(
                     this.tableName,
                     columnsAfter.get().stream().map(c -> c.deepCopy()).collect(Collectors.toList()),

--- a/mysql-replicator-augmenter/pom.xml
+++ b/mysql-replicator-augmenter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-augmenter</artifactId>
     <name>mysql-replicator-augmenter</name>

--- a/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/ActiveSchemaHelpers.java
+++ b/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/ActiveSchemaHelpers.java
@@ -6,13 +6,10 @@ import com.booking.replication.augmenter.model.schema.FullTableName;
 import com.booking.replication.augmenter.model.schema.TableSchema;
 
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,26 +17,28 @@ import javax.sql.DataSource;
 
 public class ActiveSchemaHelpers {
 
+    private static final Logger LOG = LogManager.getLogger(ActiveSchemaHelpers.class);
+
     public static TableSchema computeTableSchema(
-            String schema,
+            String schemaName,
             String tableName,
-            BasicDataSource dataSource) {
+            BasicDataSource activeSchemaDataSource) {
 
-        try (Connection connection = dataSource.getConnection()) {
-            Statement statementListColumns      = connection.createStatement();
-            Statement statementShowCreateTable  = connection.createStatement();
+        try (Connection activeSchemaConnection = activeSchemaDataSource.getConnection()) {
 
-            //  connection.getSchema() returns null for MySQL, so we do this ugly hack
-            // TODO: find nicer way
-            String[] terms = connection.getMetaData().getURL().split("/");
-            String schemaName = terms[terms.length - 1];
+            Statement statementActiveSchemaListColumns      = activeSchemaConnection.createStatement();
+            Statement statementActiveSchemaShowCreateTable  = activeSchemaConnection.createStatement();
 
             List<ColumnSchema> columnList = new ArrayList<>();
 
             ResultSet resultSet;
 
-            resultSet = statementListColumns.executeQuery(
-                    String.format(ActiveSchemaManager.LIST_COLUMNS_SQL, schema, tableName)
+            resultSet = statementActiveSchemaListColumns.executeQuery(
+                 String.format(
+                         ActiveSchemaManager.LIST_COLUMNS_SQL,
+                         schemaName,
+                         tableName
+                 )
             );
 
             while (resultSet.next()) {
@@ -69,16 +68,27 @@ public class ActiveSchemaHelpers {
                 columnList.add(columnSchema);
             }
 
-            ResultSet showCreateTableResultSet = statementShowCreateTable.executeQuery(
-                    String.format(ActiveSchemaManager.SHOW_CREATE_TABLE_SQL, tableName)
-            );
-            ResultSetMetaData showCreateTableResultSetMetadata = showCreateTableResultSet.getMetaData();
-            String tableCreateStatement = ActiveSchemaHelpers.getCreateTableStatement(tableName, showCreateTableResultSet, showCreateTableResultSetMetadata);
+            DatabaseMetaData dbm = activeSchemaConnection.getMetaData();
+            boolean tableExists = false;
+            ResultSet tables = dbm.getTables(schemaName, null, tableName, null);
+            if (tables.next()) {
+                tableExists = true; // DLL statement was not table DROP
+            }
 
+            String tableCreateStatement = "";
+            if (tableExists) {
+                ResultSet showCreateTableResultSet = statementActiveSchemaShowCreateTable.executeQuery(
+                        String.format(ActiveSchemaManager.SHOW_CREATE_TABLE_SQL, tableName)
+                );
+                ResultSetMetaData showCreateTableResultSetMetadata = showCreateTableResultSet.getMetaData();
+                tableCreateStatement = ActiveSchemaHelpers.getCreateTableStatement(tableName, showCreateTableResultSet, showCreateTableResultSetMetadata);
+            }
 
-            return new TableSchema(new FullTableName(schemaName, tableName),
+            return new TableSchema(
+                    new FullTableName(schemaName, tableName),
                     columnList,
-                    tableCreateStatement);
+                    tableCreateStatement
+            );
 
         } catch (SQLException exception) {
             throw new IllegalStateException("Could not get table schema: ", exception);
@@ -109,13 +119,18 @@ public class ActiveSchemaHelpers {
      * @return                  Rewritten query
      */
     public static String rewriteActiveSchemaName(String query, String replicantDbName) {
+
+        LOG.info("Rewriting active schema name");
+
         String dbNamePattern =
                 "( " + replicantDbName + "\\.)" +
                         "|" +
                         "( `" + replicantDbName + "`\\.)";
-        query = query.replaceAll(dbNamePattern, " ");
+        String rewritenQuery = query.replaceAll(dbNamePattern, " ");
 
-        return query;
+        LOG.info("Rewritten => { in => " + query + ", out => " + rewritenQuery + " }");
+
+        return rewritenQuery;
     }
 
 }

--- a/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/AugmenterContext.java
+++ b/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/AugmenterContext.java
@@ -141,7 +141,7 @@ public class AugmenterContext implements Closeable {
 
         this.schemaSnapshot = new AtomicReference<>();
         this.metrics = Metrics.getInstance(configuration);
-        this.binlogsBasePath = MetricRegistry.name(this.metrics.basePath(), "binlogs");
+        this.binlogsBasePath = MetricRegistry.name(this.metrics.basePath(), "augmenter", "context", "events");
 
         transactionCounter = new AtomicLong();
         transactionCounter.set(0L);
@@ -237,7 +237,7 @@ public class AugmenterContext implements Closeable {
     public synchronized void updateContext(RawEventHeaderV4 eventHeader, RawEventData eventData, String lastGTIDSet) {
 
         this.metrics.getRegistry()
-                .counter("hbase.augmenter_context.update_header.attempt").inc(1L);
+                .counter("augmenter.context.update_header.attempt").inc(1L);
 
         this.updateHeader(
                 eventHeader.getTimestamp(),
@@ -246,7 +246,7 @@ public class AugmenterContext implements Closeable {
         );
 
         this.metrics.getRegistry()
-                .counter("hbase.augmenter_context.update_header.succeeded").inc(1L);
+                .counter("augmenter.context.update_header.succeeded").inc(1L);
         isAtDDL.set(false);
 
         switch (eventHeader.getEventType()) {
@@ -261,7 +261,7 @@ public class AugmenterContext implements Closeable {
                 );
 
                 this.metrics.getRegistry()
-                        .counter("hbase.augmenter_context.type.rotate").inc(1L);
+                        .counter("augmenter.context.type.rotate").inc(1L);
 
                 RotateRawEventData rotateRawEventData = RotateRawEventData.class.cast(eventData);
 
@@ -284,7 +284,7 @@ public class AugmenterContext implements Closeable {
                 Matcher matcher;
 
                 this.metrics.getRegistry()
-                        .counter("augmenter_context.type.query").inc(1L);
+                        .counter("augmenter.context.type.query").inc(1L);
 
                 // begin
                 if (this.beginPattern.matcher(query).find()) {
@@ -310,7 +310,7 @@ public class AugmenterContext implements Closeable {
                     );
 
                     this.metrics.getRegistry()
-                            .counter("hbase.augmenter_context.type.commit").inc(1L);
+                            .counter("augmenter.context.type.commit").inc(1L);
 
                     if (!this.transaction.commit(eventHeader.getTimestamp(), transactionCounter.get())) {
                         AugmenterContext.LOG.warn("transaction already markedForCommit");
@@ -318,7 +318,7 @@ public class AugmenterContext implements Closeable {
                 } else if ((matcher = this.ddlDefinerPattern.matcher(query)).find()) {
                     // ddl definer
                     this.metrics.getRegistry()
-                            .counter("hbase.augmenter_context.type.ddl_definer").inc(1L);
+                            .counter("augmenter.context.type.ddl_definer").inc(1L);
                     this.updateCommons(
                             true,
                             QueryAugmentedEventDataType.DDL_DEFINER,
@@ -329,7 +329,7 @@ public class AugmenterContext implements Closeable {
                 } else if ((matcher = this.ddlTablePattern.matcher(query)).find()) {
                     // ddl table
                     this.metrics.getRegistry()
-                            .counter("augmenter_context.type.ddl_table").inc(1L);
+                            .counter("augmenter.context.type.ddl_table").inc(1L);
                     String tableName = matcher.group(4);
                     Boolean shouldProcess = ( this.shouldProcessTable(tableName) && queryRawEventData.getDatabase().equals(replicatedSchema) );
                     this.updateCommons(
@@ -342,20 +342,24 @@ public class AugmenterContext implements Closeable {
 
                     // Because we don't want to create tables for non-replicated schemas
                     if ( shouldProcess ) {
+
                         this.metrics.getRegistry()
-                                .counter("hbase.augmenter_context.type.ddl_table.should_process.true").inc(1L);
+                                .counter("augmenter.context.type.ddl_table.should_process.true").inc(1L);
+
                         isAtDDL.set(true);
+
                         long schemaChangeTimestamp = eventHeader.getTimestamp();
                         this.updateSchema(query, schemaChangeTimestamp);
+
                     } else {
                         this.metrics.getRegistry()
-                                .counter("hbase.augmenter_context.type.ddl_table.should_process.false").inc(1L);
+                                .counter("augmenter.context.type.ddl_table.should_process.false").inc(1L);
                     }
 
                 } else if ((matcher = this.ddlTemporaryTablePattern.matcher(query)).find()) {
                     // ddl temp table
                     this.metrics.getRegistry()
-                            .counter("hbase.augmenter_context.type.ddl_temp_table").inc(1L);
+                            .counter("augmenter.context.type.ddl_temp_table").inc(1L);
                     this.updateCommons(
                             ( queryRawEventData.getDatabase().equals(replicatedSchema) ),
                             QueryAugmentedEventDataType.DDL_TEMPORARY_TABLE,
@@ -366,7 +370,7 @@ public class AugmenterContext implements Closeable {
                 } else if ((matcher = this.ddlViewPattern.matcher(query)).find()) {
                     // ddl view
                     this.metrics.getRegistry()
-                            .counter("hbase.augmenter_context.type.ddl_view").inc(1L);
+                            .counter("augmenter.context.type.ddl_view").inc(1L);
                     this.updateCommons(
                             ( queryRawEventData.getDatabase().equals(replicatedSchema) ),
                             QueryAugmentedEventDataType.DDL_VIEW,
@@ -376,7 +380,7 @@ public class AugmenterContext implements Closeable {
                     );
                 } else if ((matcher = this.ddlAnalyzePattern.matcher(query)).find()) {
                     this.metrics.getRegistry()
-                            .counter("hbase.augmenter_context.type.ddl_analyse").inc(1L);
+                            .counter("augmenter.context.type.ddl_analyse").inc(1L);
                     this.updateCommons(
                             false,
                             QueryAugmentedEventDataType.DDL_ANALYZE,
@@ -386,7 +390,7 @@ public class AugmenterContext implements Closeable {
                     );
                 } else {
                     this.metrics.getRegistry()
-                            .counter("hbase.augmenter_context.type.unknown").inc(1L);
+                            .counter("augmenter.context.type.unknown").inc(1L);
                     this.updateCommons(
                             false,
                             null,
@@ -400,7 +404,7 @@ public class AugmenterContext implements Closeable {
 
             case XID:
                 this.metrics.getRegistry()
-                        .counter("hbase.augmenter_context.type.xid").inc(1L);
+                        .counter("augmenter.context.type.xid").inc(1L);
 
                 XIDRawEventData xidRawEventData = XIDRawEventData.class.cast(eventData);
 
@@ -446,7 +450,7 @@ public class AugmenterContext implements Closeable {
 
             case TABLE_MAP:
                 this.metrics.getRegistry()
-                        .counter("hbase.augmenter_context.type.table_map").inc(1L);
+                        .counter("augmenter.context.type.table_map").inc(1L);
                 TableMapRawEventData tableMapRawEventData = TableMapRawEventData.class.cast(eventData);
                 this.updateCommons(
                         false,
@@ -473,7 +477,7 @@ public class AugmenterContext implements Closeable {
             case DELETE_ROWS:
             case EXT_DELETE_ROWS:
                 this.metrics.getRegistry()
-                        .counter("hbase.augmenter_context.type.insert_update_delete").inc(1L);
+                        .counter("augmenter.context.type.insert_update_delete").inc(1L);
 
                 TableIdRawEventData tableIdRawEventData = TableIdRawEventData.class.cast(eventData);
                 FullTableName eventTable = this.getEventTable(tableIdRawEventData.getTableId());
@@ -494,7 +498,7 @@ public class AugmenterContext implements Closeable {
 
             default:
                 this.metrics.getRegistry()
-                        .counter("hbase.augmenter_context.type.default").inc(1L);
+                        .counter("augmenter.context.type.default").inc(1L);
                 this.updateCommons(
                         false,
                         null,

--- a/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/filters/TableNameMergePatternFilter.java
+++ b/mysql-replicator-augmenter/src/main/java/com/booking/replication/augmenter/filters/TableNameMergePatternFilter.java
@@ -41,7 +41,7 @@ public class TableNameMergePatternFilter implements AugmenterFilter {
     @Override
     public Collection<AugmentedEvent> apply(Collection<AugmentedEvent> augmentedEvents) {
         metrics.getRegistry()
-                .counter("hbase.augmenter.filter.table_name_merge.attempt").inc(1L);
+                .counter("augmenter.filter.table_name_merge.attempt").inc(1L);
 
         Collection<AugmentedEvent> filtered = augmentedEvents.stream()
                 .map(ev -> {
@@ -78,10 +78,10 @@ public class TableNameMergePatternFilter implements AugmenterFilter {
                 .collect(Collectors.toList());
 
         metrics.getRegistry()
-                .counter("hbase.augmenter.filter.table_name_merge.success").inc(1L);
+                .counter("augmenter.filter.table_name_merge.success").inc(1L);
 
         metrics.getRegistry()
-                .counter("hbase.augmenter.filter.table_name_merge.filtered_length").inc( filtered.size() );
+                .counter("augmenter.filter.table_name_merge.filtered_length").inc( filtered.size() );
 
         return filtered;
     }

--- a/mysql-replicator-augmenter/src/test/java/com/booking/replication/augmenter/active/schema/AugmenterTest.java
+++ b/mysql-replicator-augmenter/src/test/java/com/booking/replication/augmenter/active/schema/AugmenterTest.java
@@ -47,17 +47,22 @@ public class AugmenterTest {
         String query_3    = "CREATE TABLE `test`.`test` (i INT, c CHAR(10)) ENGINE = BLACKHOLE;";
         String expected_3 = "CREATE TABLE `test` (i INT, c CHAR(10)) ENGINE = BLACKHOLE;";
 
+        // table swap case
+        String query_4 = "RENAME TABLE `test`.`SomeTable` TO `test`.`SomeTable_old`, `test`.`SomeTable_new` TO `test`.`SomeTable`";
+        String expected_4 = "RENAME TABLE `SomeTable` TO `SomeTable_old`, `SomeTable_new` TO `SomeTable`";
 
         String replicantDbName = "test";
 
         String rewritten_1 = ActiveSchemaHelpers.rewriteActiveSchemaName(query_1,replicantDbName);
         String rewritten_2 = ActiveSchemaHelpers.rewriteActiveSchemaName(query_2,replicantDbName);
         String rewritten_3 = ActiveSchemaHelpers.rewriteActiveSchemaName(query_3,replicantDbName);
+        String rewritten_4 = ActiveSchemaHelpers.rewriteActiveSchemaName(query_4,replicantDbName);
 
 
         assertEquals(expected_1, rewritten_1);
         assertEquals(expected_2, rewritten_2);
         assertEquals(expected_3, rewritten_3);
+        assertEquals(expected_4, rewritten_4);
 
     }
 }

--- a/mysql-replicator-commons/pom.xml
+++ b/mysql-replicator-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>replicator</artifactId>
         <groupId>com.booking.replication</groupId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-commons</artifactId>
     <name>mysql-replicator-commons</name>

--- a/mysql-replicator-commons/src/main/java/com/booking/replication/commons/checkpoint/Checkpoint.java
+++ b/mysql-replicator-commons/src/main/java/com/booking/replication/commons/checkpoint/Checkpoint.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 @SuppressWarnings("unused")
 public class Checkpoint implements Serializable, Comparable<Checkpoint> {
+
     private long timestamp;
     private long serverId;
     private GTID gtid;

--- a/mysql-replicator-commons/src/main/java/com/booking/replication/commons/metrics/Metrics.java
+++ b/mysql-replicator-commons/src/main/java/com/booking/replication/commons/metrics/Metrics.java
@@ -79,8 +79,8 @@ public abstract class Metrics<CloseableReporter extends Closeable & Reporter> im
     public Metrics(Map<String, Object> configuration) {
         this.registry = new MetricRegistry();
         this.reporter = this.getReporter(configuration, this.registry);
-        String base = String.valueOf(configuration.getOrDefault(Configuration.BASE_PATH, "replicator"));
-        this.basePath = MetricRegistry.name(base, String.valueOf(configuration.getOrDefault(Configuration.MYSQL_SCHEMA, "db")));
+        String base = String.valueOf(configuration.getOrDefault(Configuration.BASE_PATH, ""));
+        this.basePath = MetricRegistry.name(base);
     }
 
     public MetricRegistry getRegistry() {

--- a/mysql-replicator-coordinator/pom.xml
+++ b/mysql-replicator-coordinator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-coordinator</artifactId>
     <name>mysql-replicator-coordinator</name>

--- a/mysql-replicator-streams/pom.xml
+++ b/mysql-replicator-streams/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-streams</artifactId>
     <name>mysql-replicator-streams</name>

--- a/mysql-replicator-supplier-model/pom.xml
+++ b/mysql-replicator-supplier-model/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-supplier-model</artifactId>
     <name>mysql-replicator-supplier-model</name>

--- a/mysql-replicator-supplier/pom.xml
+++ b/mysql-replicator-supplier/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-replicator-supplier</artifactId>
     <name>mysql-replicator-supplier</name>

--- a/mysql-replicator/pom.xml
+++ b/mysql-replicator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.booking.replication</groupId>
         <artifactId>replicator</artifactId>
-        <version>0.16.0-rc1-SNAPSHOT</version>
+        <version>0.16.0-rc2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mysql-replicator</artifactId>

--- a/mysql-replicator/src/main/java/com/booking/replication/Replicator.java
+++ b/mysql-replicator/src/main/java/com/booking/replication/Replicator.java
@@ -122,7 +122,7 @@ public class Replicator {
         this.partitioner        = Partitioner.build(configuration);
         this.applier            = Applier.build(configuration);
         
-	this.lastSafeCheckpoint = new AtomicLong(0L);
+	    this.lastSafeCheckpoint = new AtomicLong(0L);
 
         this.checkpointApplier = CheckpointApplier.build(configuration,
                 this.coordinator,
@@ -155,10 +155,10 @@ public class Replicator {
                 .tasks(tasks)
                 .partitioner((events, totalPartitions) -> {
                     this.metrics.getRegistry()
-                            .counter("hbase.streams.destination.partitioner.event.apply.attempt").inc(1L);
+                            .counter("streams.destination.partitioner.event.apply.attempt").inc(1L);
                     Integer partitionNumber = this.partitioner.apply(events.iterator().next(), totalPartitions);
                     this.metrics.getRegistry()
-                            .counter("hbase.streams.destination.partitioner.event.apply.success").inc(1L);
+                            .counter("streams.destination.partitioner.event.apply.success").inc(1L);
                     return partitionNumber;
                 })
                 .useDefaultQueueType()

--- a/mysql-replicator/src/main/java/com/booking/replication/checkpoint/CoordinatorCheckpointApplier.java
+++ b/mysql-replicator/src/main/java/com/booking/replication/checkpoint/CoordinatorCheckpointApplier.java
@@ -51,26 +51,36 @@ public class CoordinatorCheckpointApplier implements CheckpointApplier {
                 checkpointsSeenSoFar.addAll(checkpointBuffer.getBufferedSoFar());
             }
 
-            List<Checkpoint> checkpointsSeenWithGtidSet = checkpointsSeenSoFar
-                    .stream()
-                    .filter(c -> (c.getGtidSet() != null && !c.getGtidSet().equals(""))).collect(Collectors.toList());
+            List<Checkpoint> checkpointsSeenWithGtidSet = new ArrayList<>();
+            for (Checkpoint c: checkpointsSeenSoFar) {
+                if ((c.getGtidSet() != null) && !c.getGtidSet().equals("") && c.getTimestamp() > 0) {
+                    checkpointsSeenWithGtidSet.add(c);
+                }
+            }
 
             int currentSize = checkpointsSeenWithGtidSet.size();
 
-            LOG.info("Checkpoints seen in last " + period + "ms, [total/withGTIDSet]: " + checkpointsSeenSoFar.size() + "/" + checkpointsSeenWithGtidSet.size());
+            LOG.info("Checkpoints seen in last " + period + "ms, [total/valid]: " + checkpointsSeenSoFar.size() + "/" + checkpointsSeenWithGtidSet.size());
 
             if (currentSize > 0) {
 
-                Checkpoint safeCheckpoint = gtidSetAlgebra.getSafeCheckpoint(checkpointsSeenSoFar);
+                Checkpoint safeCheckpoint = gtidSetAlgebra.getSafeCheckpoint(checkpointsSeenWithGtidSet);
+
+                LOG.info("CheckpointApplier, calculated safe checkpoint from checkpointsSeenSoFar.");
 
                 if (safeCheckpoint != null && !safeCheckpoint.getGtidSet().equals("")) {
 
                     LOG.info("CheckpointApplier, storing safe checkpoint: " + safeCheckpoint.getGtidSet());
+
                     try {
+
                         this.storage.saveCheckpoint(this.path, safeCheckpoint);
                         CoordinatorCheckpointApplier.LOG.info("CheckpointApplier, stored checkpoint: " + safeCheckpoint.toString());
+
                         this.lastExecution.set(System.currentTimeMillis());
+
                         safeCheckpointCallback.accept(safeCheckpoint);
+
                     } catch (IOException exception) {
                         CoordinatorCheckpointApplier.LOG.info( "error saving checkpoint", exception);
                     }
@@ -78,6 +88,8 @@ public class CoordinatorCheckpointApplier implements CheckpointApplier {
                     throw new RuntimeException("Could not find safe checkpoint. Not safe to continue running!");
                 }
 
+            } else {
+                LOG.info("CheckpointApplier: No checkpoints observed since last checkpointStore");
             }
         }, period, period, TimeUnit.MILLISECONDS);
     }
@@ -108,6 +120,5 @@ public class CoordinatorCheckpointApplier implements CheckpointApplier {
             this.executor.shutdownNow();
         }
     }
-
 
 }

--- a/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/SplitTransactionTestImpl.groovy
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/SplitTransactionTestImpl.groovy
@@ -96,7 +96,6 @@ class SplitTransactionTestImpl implements ReplicatorHBasePipelineIntegrationTest
 
         //  sleep_until_next_second
         long nextSecond = sleepUntilAndGetNextSecond()
-        System.out.println("nextSecond => " + nextSecond);
 
         // commit long transaction
         // UPDATE 2

--- a/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/TableWhiteListTest.groovy
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/TableWhiteListTest.groovy
@@ -31,7 +31,6 @@ class TableWhiteListTest implements ReplicatorHBasePipelineIntegrationTest {
 
     @Override
     Map<String, Object> perTestConfiguration(Map<String,Object> genericConfig) {
-        println "...TableWhiteListTest.getConfiguration() called, setting INCLUDE_TABLE"
         genericConfig.put(AugmenterContext.Configuration.INCLUDE_TABLE, [ TABLE_NAME_INCLUDED ]);
         println genericConfig.entrySet().toArray().join(":")
         return genericConfig;

--- a/mysql-replicator/src/test/java/com/booking/replication/it/kafka/ReplicatorKafkaAvroTest.java
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/kafka/ReplicatorKafkaAvroTest.java
@@ -74,7 +74,7 @@ public class ReplicatorKafkaAvroTest {
     private static final String MYSQL_INIT_SCRIPT = "mysql.init.sql";
     private static final String MYSQL_TEST_SCRIPT = "mysql.binlog.test.sql";
     private static final String MYSQL_CONF_FILE = "my.cnf";
-    private static final int TRANSACTION_LIMIT = 5;
+    private static final int TRANSACTION_LIMIT = 100;
     private static final String CONNECTION_URL_FORMAT = "jdbc:mysql://%s:%d/%s";
 
     private static final String KAFKA_REPLICATOR_TOPIC_NAME = "replicator";
@@ -243,7 +243,7 @@ public class ReplicatorKafkaAvroTest {
 
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_HOSTNAME, ReplicatorKafkaAvroTest.mysqlActiveSchema.getHost());
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PORT, String.valueOf(ReplicatorKafkaAvroTest.mysqlActiveSchema.getPort()));
-        configuration.put(ActiveSchemaManager.Configuration.MYSQL_SCHEMA, ReplicatorKafkaAvroTest.MYSQL_ACTIVE_SCHEMA);
+        configuration.put(ActiveSchemaManager.Configuration.MYSQL_ACTIVE_SCHEMA, ReplicatorKafkaAvroTest.MYSQL_ACTIVE_SCHEMA);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_USERNAME, ReplicatorKafkaAvroTest.MYSQL_ROOT_USERNAME);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PASSWORD, ReplicatorKafkaAvroTest.MYSQL_PASSWORD);
 

--- a/mysql-replicator/src/test/java/com/booking/replication/it/slave_failover/SlaveFailoverTest.java
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/slave_failover/SlaveFailoverTest.java
@@ -269,7 +269,7 @@ public class SlaveFailoverTest {
 
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_HOSTNAME, mysqlActiveSchema.getHost());
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PORT, String.valueOf(mysqlActiveSchema.getPort()));
-        configuration.put(ActiveSchemaManager.Configuration.MYSQL_SCHEMA, MYSQL_ACTIVE_SCHEMA);
+        configuration.put(ActiveSchemaManager.Configuration.MYSQL_ACTIVE_SCHEMA, MYSQL_ACTIVE_SCHEMA);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_USERNAME, MYSQL_ROOT_USERNAME);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PASSWORD, MYSQL_PASSWORD);
 

--- a/mysql-replicator/src/test/java/com/booking/utils/BootstrapReplicatorTest.java
+++ b/mysql-replicator/src/test/java/com/booking/utils/BootstrapReplicatorTest.java
@@ -15,7 +15,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testcontainers.containers.Network;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -82,7 +81,7 @@ public class BootstrapReplicatorTest {
 
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_HOSTNAME, BootstrapReplicatorTest.mysqlActiveSchema.getHost());
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PORT, String.valueOf(BootstrapReplicatorTest.mysqlActiveSchema.getPort()));
-        configuration.put(ActiveSchemaManager.Configuration.MYSQL_SCHEMA, BootstrapReplicatorTest.MYSQL_ACTIVE_SCHEMA);
+        configuration.put(ActiveSchemaManager.Configuration.MYSQL_ACTIVE_SCHEMA, BootstrapReplicatorTest.MYSQL_ACTIVE_SCHEMA);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_USERNAME, BootstrapReplicatorTest.MYSQL_ROOT_USERNAME);
         configuration.put(ActiveSchemaManager.Configuration.MYSQL_PASSWORD, BootstrapReplicatorTest.MYSQL_PASSWORD);
         configuration.put(Augmenter.Configuration.BOOTSTRAP, BootstrapReplicatorTest.BOOTSTRAP_ACTIVE);
@@ -92,7 +91,7 @@ public class BootstrapReplicatorTest {
         configuration.put(KafkaApplier.Configuration.FORMAT, "avro");
 
         bootstrapReplicator = new BootstrapReplicator(configuration);
-        
+
         AtomicBoolean inProgress = new AtomicBoolean();
         bootstrapReplicator.run(inProgress);
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.booking.replication</groupId>
     <artifactId>replicator</artifactId>
     <packaging>pom</packaging>
-    <version>0.16.0-rc1-SNAPSHOT</version>
+    <version>0.16.0-rc2-SNAPSHOT</version>
     <name>replicator</name>
     <description>MySQL Replicator</description>
     <url>https://github.com/mysql-time-machine/replicator</url>
@@ -33,7 +33,7 @@
         <curator.version>4.0.1</curator.version>
         <mysql-connector.version>5.1.47</mysql-connector.version>
         <mysql-binlog-connector.version>0.16.1</mysql-binlog-connector.version>
-        <commons-dbcp2.version>2.4.0</commons-dbcp2.version>
+        <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
         <kafka.version>1.1.0</kafka.version>
         <dropwizard.metrics.version>4.0.2</dropwizard.metrics.version>
         <avro.version>1.8.2</avro.version>

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ else
     CHAIN=$1
 fi
 
-java -Xms1024m -Xmx2048m -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dlog4j.configurationFile=conf/log4j2.${CHAIN}.xml ${DEBUG} -jar mysql-replicator-0.16.0-rc1-SNAPSHOT/mysql-replicator-0.16.0-rc1-SNAPSHOT.jar --config-file conf/replicator.${CHAIN}.yml &
+java -Xms1024m -Xmx2048m -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dlog4j.configurationFile=conf/log4j2.${CHAIN}.xml ${DEBUG} -jar mysql-replicator-0.16.0-rc2-SNAPSHOT/mysql-replicator-0.16.0-rc2-SNAPSHOT.jar --config-file conf/replicator.${CHAIN}.yml &
 
 # remote profiling
-#java -Xms1024m -Xmx4028m -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.s   un.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0 -Djava.u   til.logging.manager=org.apache.logging.log4j.jul.LogManager -Dlog4j.configurat   ionFile=conf/log4j2.${CHAIN}.xml ${DEBUG} -jar mysql-replicator-0.16.0-rc1-SNAPSHOT/mysql-replicator-0.16.0-rc1-SNAPSHOT.jar --config-file conf/replicat   o   r.${CHAIN}.yml &
+#java -Xms1024m -Xmx4028m -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0 -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dlog4j.configurationFile=conf/log4j2.${CHAIN}.xml ${DEBUG} -jar mysql-replicator-0.16.0-rc2-SNAPSHOT/mysql-replicator-0.16.0-rc2-SNAPSHOT.jar --config-file conf/replicator.${CHAIN}.yml &


### PR DESCRIPTION
Contains:

- Bug fixes:
    - active schema name rewrite for DLLs that use full table name `schema`.`table`
    - bug fix for load schema in case when table is dropped from active schema;
    - bug fix for table swap schema change case
    - bug fix for GTID checkpoint processing in case of out of order transactions

- Consistency improvements, cleanup and tests:
    - replace warning with RuntimeException in case when ActiveSchema cannot be synced.
    - always require binlog_row_image=full; detect and throw RuntimeException if this changes during the replication.
    - more consistent metric naming.
    - JSONKafka integration test