### PR TITLE
Adding support for validator in Replicator v016

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 .idea/
 dependency-reduced-pom.xml
 target
-
+.DS_Store
 # Avoid including generated definitions in git
 mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/definitions/

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 dependency-reduced-pom.xml
 target
 .DS_Store
+
 # Avoid including generated definitions in git
 mysql-replicator-augmenter-model/src/main/java/com/booking/replication/augmenter/model/definitions/

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/Applier.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/Applier.java
@@ -4,6 +4,7 @@ import com.booking.replication.applier.console.ConsoleApplier;
 import com.booking.replication.applier.count.CountApplier;
 import com.booking.replication.applier.hbase.HBaseApplier;
 import com.booking.replication.applier.kafka.KafkaApplier;
+import com.booking.replication.applier.validation.ValidationService;
 import com.booking.replication.augmenter.model.event.AugmentedEvent;
 
 import org.apache.logging.log4j.LogManager;
@@ -57,6 +58,8 @@ public interface Applier extends Function<Collection<AugmentedEvent>, Boolean>, 
     @Override
     default void close() throws IOException {
     }
+
+    ValidationService buildValidationService(Map<String, Object> configuration);
 
     static Applier build(Map<String, Object> configuration) {
         try {

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/console/ConsoleApplier.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/console/ConsoleApplier.java
@@ -60,13 +60,11 @@ public class ConsoleApplier implements Applier {
     }
 
     @Override
-    public boolean forceFlush() {
-        return false;
-    }
+    public ValidationService buildValidationService(Map<String, Object> configuration) { return null; }
 
     @Override
-    public ValidationService buildValidationService(Map<String, Object> configuration) {
-        return null;
+    public boolean forceFlush() {
+        return false;
     }
 
     private Set<String> getAsSet(Object object) {

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/console/ConsoleApplier.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/console/ConsoleApplier.java
@@ -2,6 +2,7 @@ package com.booking.replication.applier.console;
 
 import com.booking.replication.applier.Applier;
 import com.booking.replication.applier.kafka.KafkaApplier;
+import com.booking.replication.applier.validation.ValidationService;
 import com.booking.replication.augmenter.model.event.AugmentedEvent;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -61,6 +62,11 @@ public class ConsoleApplier implements Applier {
     @Override
     public boolean forceFlush() {
         return false;
+    }
+
+    @Override
+    public ValidationService buildValidationService(Map<String, Object> configuration) {
+        return null;
     }
 
     private Set<String> getAsSet(Object object) {

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/count/CountApplier.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/count/CountApplier.java
@@ -1,6 +1,7 @@
 package com.booking.replication.applier.count;
 
 import com.booking.replication.applier.Applier;
+import com.booking.replication.applier.validation.ValidationService;
 import com.booking.replication.augmenter.model.event.AugmentedEvent;
 import com.booking.replication.augmenter.model.event.AugmentedEventType;
 
@@ -25,6 +26,11 @@ public class CountApplier implements Applier {
     @Override
     public boolean forceFlush() {
         return false;
+    }
+
+    @Override
+    public ValidationService buildValidationService(Map<String, Object> configuration) {
+        return null;
     }
 
     @Override

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/mutation/HBaseApplierMutationGenerator.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/hbase/mutation/HBaseApplierMutationGenerator.java
@@ -34,11 +34,13 @@ public class HBaseApplierMutationGenerator {
         private final Put put;
         private final String table;
         private final String sourceRowUri;
+        private final String transactionUUID;
 
-        public PutMutation(Put put, String table, String sourceRowUri) {
+        public PutMutation(Put put, String table, String sourceRowUri, String transactionUUID) {
             this.put = put;
             this.sourceRowUri = sourceRowUri;
             this.table = table;
+            this.transactionUUID = transactionUUID;
         }
 
         public Put getPut() {
@@ -51,6 +53,10 @@ public class HBaseApplierMutationGenerator {
 
         public String getTable() {
             return table;
+        }
+
+        public String getTransactionUUID() {
+            return transactionUUID;
         }
 
         public String getTargetRowUri() {
@@ -308,20 +314,13 @@ public class HBaseApplierMutationGenerator {
         return new PutMutation(
                 put,
                 hbaseTableName,
-                null  // TODO: validator <- getRowUri(augmentedRow),
+                getRowUri(augmentedRow),
+                augmentedRow.getTransactionUUID()
         );
     }
 
     private String getRowUri(AugmentedRow row) {
 
-        // TODO: add validator config options
-        //        validation:
-        //          broker: "localhost:9092,localhost:9093"
-        //          topic: replicator_validation
-        //          tag: test_hbase
-        //          source_domain: mysql-schema
-        //          target_domain: hbase-cluster
-        // if (configuration.validationConfig == null) return null;
         String sourceDomain = row.getTableSchema().toString().toLowerCase();
 
         AugmentedEventType eventType = row.getEventType();

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/kafka/KafkaApplier.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/kafka/KafkaApplier.java
@@ -3,6 +3,7 @@ package com.booking.replication.applier.kafka;
 import com.booking.replication.applier.Applier;
 import com.booking.replication.applier.Partitioner;
 import com.booking.replication.applier.schema.registry.BCachedSchemaRegistryClient;
+import com.booking.replication.applier.validation.ValidationService;
 import com.booking.replication.augmenter.model.event.*;
 import com.booking.replication.commons.map.MapFilter;
 import com.booking.replication.commons.metrics.Metrics;
@@ -295,6 +296,12 @@ public class KafkaApplier implements Applier {
         this.partitioner.close();
         this.producers.values().forEach(Producer::close);
         this.producers.clear();
+    }
+
+    // Validation service not ready for Kafka yet
+    @Override
+    public ValidationService buildValidationService(Map<String, Object> configuration) {
+        return null;
     }
 
     private Set<String> getAsSet(Object object) {

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -76,7 +76,8 @@ public class ValidationService {
     public static ValidationService getInstance(Map<String, Object> configuration){
 
         // Validator is only available for HBase / BigTable
-        if (!((String)configuration.getOrDefault(Applier.Configuration.TYPE, "console")).toLowerCase().equals("hbase")) {
+        if (!((String)configuration.getOrDefault(Applier.Configuration.TYPE, "console")).toLowerCase().equals("hbase")
+            || configuration.getOrDefault(Configuration.VALIDATION_BROKER,null) == null) {
             return null;
         }
 

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -123,10 +123,7 @@ public class ValidationService {
     }
 
     private synchronized boolean canSubmitTask(long taskCounter) {
-        if (taskCounter >= TASK_COUNTER_MAX_RESET){
-            taskCounter = taskCounter % TASK_COUNTER_MAX_RESET;
-            validationTaskCounter.set(taskCounter);
-        }
+        if (taskCounter >= TASK_COUNTER_MAX_RESET) validationTaskCounter.set(taskCounter % TASK_COUNTER_MAX_RESET);
         return taskCounter % throttleOnePerEvery == 0;
     }
 

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -69,12 +69,13 @@ public class ValidationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidationService.class);
 
     public static class Configuration {
-        static String VALIDATION_BROKER = "validation.broker";
-        static String VALIDATION_TOPIC = "validation.topic";
-        static String VALIDATION_TAG = "validation.tag";
-        static String VALIDATION_THROTTLE_ONE_EVERY = "validation.throttle_one_every";
-        static String VALIDATION_SOURCE_DOMAIN = "validation.source_domain";
-        static String VALIDATION_TARGET_DOMAIN = "validation.target_domain";
+        private Configuration() {}
+        static final String VALIDATION_BROKER = "validation.broker";
+        static final String VALIDATION_TOPIC = "validation.topic";
+        static final String VALIDATION_TAG = "validation.tag";
+        static final String VALIDATION_THROTTLE_ONE_EVERY = "validation.throttle_one_every";
+        static final String VALIDATION_SOURCE_DOMAIN = "validation.source_domain";
+        static final String VALIDATION_TARGET_DOMAIN = "validation.target_domain";
     }
 
     public static ValidationService getInstance(Map<String, Object> configuration) {
@@ -126,7 +127,7 @@ public class ValidationService {
             taskCounter = taskCounter % TASK_COUNTER_MAX_RESET;
             validationTaskCounter.set(taskCounter);
         }
-        return taskCounter % throttleOnePerEvery == 0 ? true : false;
+        return taskCounter % throttleOnePerEvery == 0;
     }
 
     public void submitValidationTask(String id, String sourceUri, String targetUri) {

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -77,7 +77,7 @@ public class ValidationService {
         static String VALIDATION_TARGET_DOMAIN = "validation.target_domain";
     }
 
-    public static ValidationService getInstance(Map<String, Object> configuration){
+    public static ValidationService getInstance(Map<String, Object> configuration) {
 
         // Validator is only available for HBase / BigTable
         if (!((String)configuration.getOrDefault(Applier.Configuration.TYPE, "console")).equalsIgnoreCase("hbase")
@@ -115,13 +115,13 @@ public class ValidationService {
         this.tag = tag;
     }
 
-    public void registerValidationTask(String id, String sourceUri, String targetUri){
+    public void registerValidationTask(String id, String sourceUri, String targetUri) {
         long taskCounter = validationTaskCounter.incrementAndGet();
         if (canSubmitTask(taskCounter)) submitValidationTask(id,sourceUri,targetUri);
         // else drop task
     }
 
-    private synchronized boolean canSubmitTask(long taskCounter){
+    private synchronized boolean canSubmitTask(long taskCounter) {
         if (taskCounter >= TASK_COUNTER_MAX_RESET){
             taskCounter = taskCounter % TASK_COUNTER_MAX_RESET;
             validationTaskCounter.set(taskCounter);
@@ -129,7 +129,7 @@ public class ValidationService {
         return taskCounter % throttleOnePerEvery == 0 ? true : false;
     }
 
-    public void submitValidationTask(String id, String sourceUri, String targetUri){
+    public void submitValidationTask(String id, String sourceUri, String targetUri) {
         try {
             String task = mapper.writeValueAsString( new ValidationTask(tag, sourceUri, targetUri) );
             producer.send(new ProducerRecord<>(topic, id, task ));
@@ -137,5 +137,9 @@ public class ValidationService {
         } catch (JsonProcessingException e) {
             LOGGER.error("Failure serializing validation task {} {} {} {}", id, tag, sourceUri, targetUri, e);
         }
+    }
+
+    public long getValidationTaskCounter() {
+        return this.validationTaskCounter.get();
     }
 }

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -116,15 +116,12 @@ public class ValidationService {
     }
 
     public void registerValidationTask(String id, String sourceUri, String targetUri){
-
         if (throttlingInterval <= 0 || updateLastRegistrationTime()) submitValidationTask(id,sourceUri,targetUri);
-
     }
 
     private boolean updateLastRegistrationTime(){
 
         long currentTime = System.currentTimeMillis();
-
         boolean result = false;
 
         // Double-checked locking WITHOUT volatile:
@@ -132,48 +129,28 @@ public class ValidationService {
         // First read may not be consistent (is racy) cause java does not guarantee atomicity for writing longs. But taking,
         // into account the nature of the value it is not a problem
         if (isTimeWindowEmpty(currentTime)){
-
             if (registrationWeakLock.compareAndSet(false,true)){
-
                 if (isTimeWindowEmpty(currentTime)){
-
                     lastRegistrationTime = currentTime;
-
                     result = true;
-
                 }
-
                 registrationWeakLock.set(false);
             }
-
         }
-
         return result;
     }
 
     private boolean isTimeWindowEmpty(long currentTime){
-
         return currentTime - lastRegistrationTime > throttlingInterval;
-
     }
 
     public void submitValidationTask(String id, String sourceUri, String targetUri){
-
         try {
-
             String task = mapper.writeValueAsString( new ValidationTask(tag, sourceUri, targetUri) );
-
             producer.send(new ProducerRecord<>(topic, id, task ));
-
             LOGGER.info("Validation task {} {} submitted", id, task);
-
         } catch (JsonProcessingException e) {
-
             LOGGER.error("Failure serializing validation task {} {} {} {}", id, tag, sourceUri, targetUri, e);
-
         }
-
     }
-
-
 }

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -12,10 +12,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Created by dbatheja on 16/12/2019.
+ */
 public class ValidationService {
 
     private static final long VALIDATOR_THROTTLING_DEFAULT = 100;

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -1,0 +1,179 @@
+package com.booking.replication.applier.validation;
+
+import com.booking.replication.applier.Applier;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ValidationService {
+
+    private static final class ValidationTask {
+
+        private static final Map<String,Object> TARGET_TRANSFORMATION;
+        static {
+            Map<String,Object> map = new HashMap<>();
+            map.put("row_status_column","row_status");
+            List<String> ignore_columns = new ArrayList<>();
+            ignore_columns.add("_replicator_uuid");
+            ignore_columns.add("_replicator_xid");
+            ignore_columns.add("_transaction_uuid");
+            map.put("ignore_columns", ignore_columns);
+            TARGET_TRANSFORMATION = Collections.unmodifiableMap(map);
+        }
+
+        private static final Map<String,Object> SOURCE_TRANSFORMATION;
+        static {
+            Map<String,Object> map = new HashMap<>();
+            map.put("map_null","NULL");
+            map.put("convert_timestamps_to_epoch",true);
+            SOURCE_TRANSFORMATION = Collections.unmodifiableMap(map);
+        }
+
+        @JsonProperty("tag")
+        private final String tag;
+
+        @JsonProperty("source")
+        private final String source;
+
+        @JsonProperty("target")
+        private final String target;
+
+        @JsonProperty("target_transformation")
+        private final Map<String,Object> targetTransformation = TARGET_TRANSFORMATION;
+
+        @JsonProperty("source_transformation")
+        private final  Map<String,Object> sourceTransformation = SOURCE_TRANSFORMATION;
+
+        private ValidationTask(String tag, String sourceUri, String targetUri) {
+            this.tag = tag;
+            this.source = sourceUri;
+            this.target = targetUri;
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationService.class);
+
+    public interface Configuration {
+        long VALIDATOR_THROTTLING_DEFAULT = TimeUnit.SECONDS.toMillis(5);
+        String VALIDATION_BROKER = "validation.broker";
+        String VALIDATION_TOPIC = "validation.topic";
+        String VALIDATION_TAG = "validation.tag";
+        String VALIDATION_THROTTLING = "validation.throttling";
+        String VALIDATION_SOURCE_DOMAIN = "validation.source_domain";
+        String VALIDATION_TARGET_DOMAIN = "validation.target_domain";
+    }
+
+    public static ValidationService getInstance(Map<String, Object> configuration){
+
+        // Validator is only available for HBase / BigTable
+        if (!((String)configuration.getOrDefault(Applier.Configuration.TYPE, "console")).toLowerCase().equals("hbase")) {
+            return null;
+        }
+
+        if ( configuration.getOrDefault(Configuration.VALIDATION_BROKER,null) == null
+             || configuration.getOrDefault(Configuration.VALIDATION_SOURCE_DOMAIN,null) == null
+             || configuration.getOrDefault(Configuration.VALIDATION_TARGET_DOMAIN,null) == null
+             || configuration.getOrDefault(Configuration.VALIDATION_TOPIC, null) == null ) {
+            throw new IllegalArgumentException("Bad validation configuration");
+        }
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", (String)configuration.get(Configuration.VALIDATION_BROKER));
+        Producer<String,String> producer = new KafkaProducer(properties, new StringSerializer(), new StringSerializer());
+
+        return new ValidationService(producer,
+                                     (String)configuration.get(Configuration.VALIDATION_TOPIC),
+                                     (String)configuration.get(Configuration.VALIDATION_TAG),
+                                     (long)configuration.getOrDefault(Configuration.VALIDATION_THROTTLING, Configuration.VALIDATOR_THROTTLING_DEFAULT));
+    }
+
+    private final long throttlingInterval;
+    private long lastRegistrationTime;
+
+    private final AtomicBoolean registrationWeakLock = new AtomicBoolean();
+
+    private final Producer<String, String> producer;
+    private final String topic;
+    private final String tag;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public ValidationService(Producer<String, String> producer, String topic,String tag, long throttlingInterval) {
+
+        this.throttlingInterval = throttlingInterval;
+        this.producer = producer;
+        this.topic = topic;
+        this.tag = tag;
+
+    }
+
+    public void registerValidationTask(String id, String sourceUri, String targetUri){
+
+        if (throttlingInterval <= 0 || updateLastRegistrationTime()) submitValidationTask(id,sourceUri,targetUri);
+
+    }
+
+    private boolean updateLastRegistrationTime(){
+
+        long currentTime = System.currentTimeMillis();
+
+        boolean result = false;
+
+        // Double-checked locking WITHOUT volatile:
+        // Write to lastRegistrationTime happens-before its second read cause AtomicBoolean write-read sequence is in between.
+        // First read may not be consistent (is racy) cause java does not guarantee atomicity for writing longs. But taking,
+        // into account the nature of the value it is not a problem
+        if (isTimeWindowEmpty(currentTime)){
+
+            if (registrationWeakLock.compareAndSet(false,true)){
+
+                if (isTimeWindowEmpty(currentTime)){
+
+                    lastRegistrationTime = currentTime;
+
+                    result = true;
+
+                }
+
+                registrationWeakLock.set(false);
+            }
+
+        }
+
+        return result;
+    }
+
+    private boolean isTimeWindowEmpty(long currentTime){
+
+        return currentTime - lastRegistrationTime > throttlingInterval;
+
+    }
+
+    public void submitValidationTask(String id, String sourceUri, String targetUri){
+
+        try {
+
+            String task = mapper.writeValueAsString( new ValidationTask(tag, sourceUri, targetUri) );
+
+            producer.send(new ProducerRecord<>(topic, id, task ));
+
+            LOGGER.info("Validation task {} {} submitted", id, task);
+
+        } catch (JsonProcessingException e) {
+
+            LOGGER.error("Failure serializing validation task {} {} {} {}", id, tag, sourceUri, targetUri, e);
+
+        }
+
+    }
+
+
+}

--- a/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
+++ b/mysql-replicator-applier/src/main/java/com/booking/replication/applier/validation/ValidationService.java
@@ -68,13 +68,13 @@ public class ValidationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidationService.class);
 
-    public interface Configuration {
-        String VALIDATION_BROKER = "validation.broker";
-        String VALIDATION_TOPIC = "validation.topic";
-        String VALIDATION_TAG = "validation.tag";
-        String VALIDATION_THROTTLE_ONE_EVERY = "validation.throttle_one_every";
-        String VALIDATION_SOURCE_DOMAIN = "validation.source_domain";
-        String VALIDATION_TARGET_DOMAIN = "validation.target_domain";
+    public static class Configuration {
+        static String VALIDATION_BROKER = "validation.broker";
+        static String VALIDATION_TOPIC = "validation.topic";
+        static String VALIDATION_TAG = "validation.tag";
+        static String VALIDATION_THROTTLE_ONE_EVERY = "validation.throttle_one_every";
+        static String VALIDATION_SOURCE_DOMAIN = "validation.source_domain";
+        static String VALIDATION_TARGET_DOMAIN = "validation.target_domain";
     }
 
     public static ValidationService getInstance(Map<String, Object> configuration){
@@ -126,10 +126,7 @@ public class ValidationService {
             taskCounter = taskCounter % TASK_COUNTER_MAX_RESET;
             validationTaskCounter.set(taskCounter);
         }
-        if (taskCounter % throttleOnePerEvery == 0) {
-            return true;
-        }
-        return false;
+        return taskCounter % throttleOnePerEvery == 0 ? true : false;
     }
 
     public void submitValidationTask(String id, String sourceUri, String targetUri){

--- a/mysql-replicator-applier/src/test/java/com/booking/replication/applier/validation/ValidationServiceTest.java
+++ b/mysql-replicator-applier/src/test/java/com/booking/replication/applier/validation/ValidationServiceTest.java
@@ -43,9 +43,10 @@ public class ValidationServiceTest {
         configuration.put(Applier.Configuration.TYPE, "hbase");
         ValidationService validationService = ValidationService.getInstance(configuration);
         Assert.assertNotNull(validationService);
-        validationService.registerValidationTask("sample-id", "mysql://","hbase://");
-        validationService.registerValidationTask("sample-id 2", "mysql://","hbase://");
-        Assert.assertEquals(2L, validationService.getValidationTaskCounter());
+        for (int i=0; i<10; i++){
+            validationService.registerValidationTask("sample-id-"+ i, "mysql://","hbase://");
+        }
+        Assert.assertEquals(10L, validationService.getValidationTaskCounter());
     }
 
     @Test

--- a/mysql-replicator-applier/src/test/java/com/booking/replication/applier/validation/ValidationServiceTest.java
+++ b/mysql-replicator-applier/src/test/java/com/booking/replication/applier/validation/ValidationServiceTest.java
@@ -1,0 +1,58 @@
+package com.booking.replication.applier.validation;
+
+import com.booking.replication.applier.Applier;
+import com.booking.replication.commons.services.ServicesControl;
+import com.booking.replication.commons.services.ServicesProvider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ValidationServiceTest {
+    private static final Logger LOG = LogManager.getLogger(ValidationServiceTest.class);
+    private static ServicesControl servicesControl;
+    private static String TOPIC_NAME = "replicator_validation";
+    private static Map<String, Object> configuration;
+
+    @BeforeClass
+    public static void Before() {
+        configuration = new HashMap<>();
+        configuration.put(Applier.Configuration.TYPE, "hbase");
+        configuration.put(ValidationService.Configuration.VALIDATION_BROKER, "localhost:9092");
+        configuration.put(ValidationService.Configuration.VALIDATION_THROTTLE_ONE_EVERY, "1");
+        configuration.put(ValidationService.Configuration.VALIDATION_TOPIC, "replicator_validation");
+        configuration.put(ValidationService.Configuration.VALIDATION_TAG, "test_hbase");
+        configuration.put(ValidationService.Configuration.VALIDATION_SOURCE_DOMAIN, "mysql-schema");
+        configuration.put(ValidationService.Configuration.VALIDATION_TARGET_DOMAIN, "hbase-cluster");
+        ValidationServiceTest.servicesControl = ServicesProvider.build(ServicesProvider.Type.CONTAINERS).startKafka(ValidationServiceTest.TOPIC_NAME, 1, 1);
+    }
+
+    @Test
+    public void testValidationServiceCounter() {
+        LOG.info("ValidationServiceTest.testValidationServiceCounter() called");
+        configuration.put(Applier.Configuration.TYPE, "hbase");
+        ValidationService validationService = ValidationService.getInstance(configuration);
+        Assert.assertNotNull(validationService);
+        validationService.registerValidationTask("sample-id", "mysql://","hbase://");
+        validationService.registerValidationTask("sample-id 2", "mysql://","hbase://");
+        Assert.assertEquals(2L, validationService.getValidationTaskCounter());
+    }
+
+    @Test
+    public void testValidationServiceNull() {
+        LOG.info("ValidationServiceTest.testValidationServiceNull() called");
+        configuration.put(Applier.Configuration.TYPE, "console");
+        ValidationService validationService = ValidationService.getInstance(configuration);
+        Assert.assertNull(validationService);
+    }
+
+    @AfterClass
+    public static void After() {
+        ValidationServiceTest.servicesControl.close();
+    }
+}

--- a/mysql-replicator/src/test/java/com/booking/replication/it/hbase/ReplicatorHBasePipelineIntegrationTestRunner.groovy
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/hbase/ReplicatorHBasePipelineIntegrationTestRunner.groovy
@@ -103,7 +103,7 @@ class ReplicatorHBasePipelineIntegrationTestRunner extends Specification {
             new MicrosecondValidationTestImpl(),
             new LongTransactionTestImpl(),
             new PayloadTableTestImpl(),
-            new SplitTransactionTestImpl()
+            new SplitTransactionTestImpl(),
     ]
 
     @Shared ServicesProvider servicesProvider = ServicesProvider.build(ServicesProvider.Type.CONTAINERS)
@@ -201,6 +201,8 @@ class ReplicatorHBasePipelineIntegrationTestRunner extends Specification {
         mysqlBinaryLog.close()
         mysqlActiveSchema.close()
         zookeeper.close()
+        kafka.close()
+        kafkaZk.close()
 
         LOG.info("pipeline stopped")
 

--- a/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/ValidationTestImpl.groovy
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/ValidationTestImpl.groovy
@@ -1,0 +1,114 @@
+package com.booking.replication.it.hbase.impl
+
+import com.booking.replication.augmenter.model.event.AugmentedEventHeader
+import com.booking.replication.augmenter.model.event.AugmentedEventType
+import com.booking.replication.commons.services.ServicesControl
+import com.booking.replication.it.hbase.ReplicatorHBasePipelineIntegrationTest
+import com.booking.replication.it.hbase.ReplicatorHBasePipelineIntegrationTestRunner
+import com.booking.replication.it.kafka.ReplicatorKafkaJSONTest
+import com.booking.replication.it.util.MySQL
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+
+class ValidationTestImpl implements ReplicatorHBasePipelineIntegrationTest {
+    static String HBASE_COLUMN_FAMILY_NAME = "d"
+    static String SCHEMA_NAME = "replicator"
+    static String VALIDATION_CONSUMER_GROUP = "validation-group"
+    static String TABLE_NAME = "sometable"
+    static int TOTAL_DMLS = 1000
+
+    @Override
+    String testName() {
+        return "HbaseValidationTest"
+    }
+
+    @Override
+    void doAction(ServicesControl mysqlReplicant) {
+        // get handle
+        def replicant = MySQL.getSqlHandle(
+                false,
+                SCHEMA_NAME,
+                mysqlReplicant
+        )
+
+        // CREATE
+        def sqlCreate = sprintf("""
+        CREATE TABLE
+            %s (
+            pk_part_1         varchar(5) NOT NULL DEFAULT '',
+            pk_part_2         int(11)    NOT NULL DEFAULT 0,
+            randomInt         int(11)             DEFAULT NULL,
+            randomVarchar     varchar(32)         DEFAULT NULL,
+            PRIMARY KEY       (pk_part_1,pk_part_2),
+            KEY randomVarchar (randomVarchar),
+            KEY randomInt     (randomInt)
+            ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+        """, TABLE_NAME)
+
+        replicant.execute(sqlCreate)
+        replicant.commit()
+
+        def columns = "(pk_part_1,pk_part_2,randomInt,randomVarchar)"
+
+        for (int i=0; i<TOTAL_DMLS; i++){
+            replicant.execute(sprintf(
+                    "INSERT INTO %s %s VALUES ('user',%d,%d,'c%d');", TABLE_NAME, columns, i,i,i
+            ))
+            replicant.commit()
+        }
+
+        replicant.close()
+    }
+
+    @Override
+    Object getExpectedState() {
+        return (int) (TOTAL_DMLS/(Integer.parseInt(ReplicatorHBasePipelineIntegrationTestRunner.VALIDATION_THROTTLE_ONE_EVERY)))
+    }
+
+    @Override
+    Object getActualState() throws IOException {
+
+        Map<String, Object> kafkaConfiguration = new HashMap<>();
+        kafkaConfiguration.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, ReplicatorHBasePipelineIntegrationTestRunner.VALIDATION_BROKER);
+        kafkaConfiguration.put(ConsumerConfig.GROUP_ID_CONFIG, VALIDATION_CONSUMER_GROUP);
+        kafkaConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        // println(sprintf("---------[Getting actual state from Kafka Topic %s]---------", ReplicatorHBasePipelineIntegrationTestRunner.VALIDATION_TOPIC))
+        int messagesToValidate = 0
+        try {
+            Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(kafkaConfiguration, new ByteArrayDeserializer(), new ByteArrayDeserializer())
+            consumer.subscribe(Collections.singleton(ReplicatorHBasePipelineIntegrationTestRunner.VALIDATION_TOPIC));
+
+            final int stopTryingAfter = 10; int zeroRecordsFound = 0;
+            while (true) {
+                final ConsumerRecords<Long, String> consumerPollResult = consumer.poll(1000);
+                if (consumerPollResult.count() == 0) {
+                    zeroRecordsFound++;
+                    if (zeroRecordsFound > stopTryingAfter) break;
+                    else continue;
+                }
+                consumerPollResult.forEach({ record ->
+                    messagesToValidate ++
+                });
+                consumer.commitAsync();
+            }
+            consumer.close();
+            System.out.println("Total records found in " + ReplicatorHBasePipelineIntegrationTestRunner.VALIDATION_TOPIC + " = " + messagesToValidate.toString());
+        } catch (Exception e){
+            println(e)
+        } finally {
+            return messagesToValidate
+        }
+    }
+
+    @Override
+    boolean actualEqualsExpected(Object expected, Object actual) {
+        int exp = (int) expected
+        int act = (int) actual
+        return exp == act
+    }
+}

--- a/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/ValidationTestImpl.groovy
+++ b/mysql-replicator/src/test/java/com/booking/replication/it/hbase/impl/ValidationTestImpl.groovy
@@ -1,22 +1,19 @@
 package com.booking.replication.it.hbase.impl
 
-import com.booking.replication.augmenter.model.event.AugmentedEventHeader
-import com.booking.replication.augmenter.model.event.AugmentedEventType
 import com.booking.replication.commons.services.ServicesControl
 import com.booking.replication.it.hbase.ReplicatorHBasePipelineIntegrationTest
 import com.booking.replication.it.hbase.ReplicatorHBasePipelineIntegrationTestRunner
-import com.booking.replication.it.kafka.ReplicatorKafkaJSONTest
 import com.booking.replication.it.util.MySQL
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
+/**
+ * Created by dbatheja on 20/12/2019.
+ */
 class ValidationTestImpl implements ReplicatorHBasePipelineIntegrationTest {
-    static String HBASE_COLUMN_FAMILY_NAME = "d"
     static String SCHEMA_NAME = "replicator"
     static String VALIDATION_CONSUMER_GROUP = "validation-group"
     static String TABLE_NAME = "sometable"


### PR DESCRIPTION
Augmented rows need to be sent to a kafka topic for validation.
Changes overview:
- Added a function - *buildValidationService* to `Applier` interface which enforces all Appliers to implement this method. For now, the only supported applier-validator is `HBase/Bigtable`.
- Implemented ValidationService (based on [this snippet from 0.14.6](https://github.com/mysql-time-machine/replicator/blob/release-0.14.6/src/main/java/com/booking/replication/validation/ValidationService.java)) with updated configuration fetch.